### PR TITLE
Ship and cockpit script

### DIFF
--- a/faster-than-scrap/Sandbox/Wierzba/wierzba_sandbox.tscn
+++ b/faster-than-scrap/Sandbox/Wierzba/wierzba_sandbox.tscn
@@ -23,11 +23,11 @@ skeleton = NodePath("")
 [node name="ModuleBase" parent="ModuleBase/ModuleBase" instance=ExtResource("1_3itn7")]
 hp = 1000
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="ModuleBase/ModuleBase/ModuleBase"]
+[node name="MeshInstance3D2" type="MeshInstance3D" parent="ModuleBase/ModuleBase/ModuleBase"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.3921, 0)
 mesh = SubResource("BoxMesh_8dvid")
 skeleton = NodePath("")
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="ModuleBase"]
+[node name="MeshInstance3D2" type="MeshInstance3D" parent="ModuleBase"]
 mesh = SubResource("BoxMesh_8dvid")
 skeleton = NodePath("")

--- a/faster-than-scrap/code/Player/player_ship.gd
+++ b/faster-than-scrap/code/Player/player_ship.gd
@@ -1,0 +1,29 @@
+class_name PlayerShip
+
+extends Ship
+
+@export var cockpit: Cockpit
+
+## all modules of the ship (to prevent checking the tree hierarchy)
+@export var modules: Array[Module] = []
+
+func on_game_change_state(new_state : GameState.state) -> void:
+	match new_state:
+		GameState.state.FLY:
+			_activate_modules()
+		GameState.state.PAUSE: 
+			_deactivate_modules()
+		GameState.state.CUTSCENE: 
+			_deactivate_modules()
+		GameState.state.BUILD: 
+			_deactivate_modules()
+		GameState.state.MAIN_MENU: 
+			pass
+
+func _deactivate_modules():
+	for module in modules:
+		module.active = false
+
+func _activate_modules():
+	for module in modules:
+		module.active = true

--- a/faster-than-scrap/code/game_manager.gd
+++ b/faster-than-scrap/code/game_manager.gd
@@ -3,7 +3,7 @@ class_name GameManager
 extends Node
 
 @export var game_state :GameState.state = GameState.state.FLY
-@export var ship: Ship
+@export var ship: PlayerShip
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:

--- a/faster-than-scrap/code/game_manager.gd
+++ b/faster-than-scrap/code/game_manager.gd
@@ -1,6 +1,27 @@
+class_name GameManager
+
 extends Node
 
+@export var game_state :GameState.state = GameState.state.FLY
+@export var ship: Ship
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	pass # Replace with function body.
+
+func _set_game_state(new_state: GameState.state) -> void:
+	game_state=new_state
+	ship.on_game_change_state(new_state)
+	
+	# future logic for changing state
+	match new_state:
+		GameState.state.FLY:
+			pass
+		GameState.state.PAUSE: 
+			pass
+		GameState.state.CUTSCENE: 
+			pass
+		GameState.state.BUILD: 
+			pass
+		GameState.state.MAIN_MENU: 
+			pass

--- a/faster-than-scrap/code/game_state.gd
+++ b/faster-than-scrap/code/game_state.gd
@@ -1,3 +1,5 @@
+class_name GameState
+
 extends Node
 
-enum GameState { MAIN_MENU, PAUSE, BUILD, FLY, CUTSCENE }
+enum state { MAIN_MENU, PAUSE, BUILD, FLY, CUTSCENE }

--- a/faster-than-scrap/code/ship/modules/cockpit.gd
+++ b/faster-than-scrap/code/ship/modules/cockpit.gd
@@ -1,0 +1,16 @@
+class_name Cockpit
+
+extends Module
+
+## Class for cockpit
+## The most important part of the ship.
+## It informs the ship on death.
+
+func _on_destroy() -> void:
+	super() # call base
+	ship.on_destroy() # inform ship of death
+
+## overriden method
+## cockpit isn't detachable
+func detachable() -> bool:
+	return false

--- a/faster-than-scrap/code/ship/modules/module.gd
+++ b/faster-than-scrap/code/ship/modules/module.gd
@@ -58,3 +58,6 @@ func _explode() -> void:
 	# TODO create particles object,
 	# which will die after some die by itself
 	pass
+
+func detachable() -> bool:
+	return true

--- a/faster-than-scrap/code/ship/ship.gd
+++ b/faster-than-scrap/code/ship/ship.gd
@@ -2,10 +2,9 @@ class_name Ship
 
 extends Node3D
 
+## Base class for player and enemy
+
 var energy: float = 100
-## all modules of the ship (to prevent checking the tree hierarchy)
-@export var modules: Array[Module] = []
-var cockpit: Cockpit
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -24,27 +23,6 @@ func use_energy(amount: float) -> bool:
 ## Called whenever the energy amount changes.
 func _on_energy_change() -> void:
 	pass
-
-func on_game_change_state(new_state : GameState.state) -> void:
-	match new_state:
-		GameState.state.FLY:
-			_activate_modules()
-		GameState.state.PAUSE: 
-			_deactivate_modules()
-		GameState.state.CUTSCENE: 
-			_deactivate_modules()
-		GameState.state.BUILD: 
-			_deactivate_modules()
-		GameState.state.MAIN_MENU: 
-			pass
-
-func _deactivate_modules():
-	for module in modules:
-		module.active = false
-
-func _activate_modules():
-	for module in modules:
-		module.active = true
 
 func on_destroy() -> void: 
 	pass

--- a/faster-than-scrap/code/ship/ship.gd
+++ b/faster-than-scrap/code/ship/ship.gd
@@ -3,6 +3,9 @@ class_name Ship
 extends Node3D
 
 var energy: float = 100
+## all modules of the ship (to prevent checking the tree hierarchy)
+@export var modules: Array[Module] = []
+var cockpit: Cockpit
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -20,4 +23,28 @@ func use_energy(amount: float) -> bool:
 
 ## Called whenever the energy amount changes.
 func _on_energy_change() -> void:
+	pass
+
+func on_game_change_state(new_state : GameState.state) -> void:
+	match new_state:
+		GameState.state.FLY:
+			_activate_modules()
+		GameState.state.PAUSE: 
+			_deactivate_modules()
+		GameState.state.CUTSCENE: 
+			_deactivate_modules()
+		GameState.state.BUILD: 
+			_deactivate_modules()
+		GameState.state.MAIN_MENU: 
+			pass
+
+func _deactivate_modules():
+	for module in modules:
+		module.active = false
+
+func _activate_modules():
+	for module in modules:
+		module.active = true
+
+func on_destroy() -> void: 
 	pass

--- a/faster-than-scrap/prefabs/modules/cockpit.tscn
+++ b/faster-than-scrap/prefabs/modules/cockpit.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=3 format=3 uid="uid://3xoku32llsaa"]
+
+[ext_resource type="Script" path="res://code/ship/modules/cockpit.gd" id="1_q5512"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_6fvvx"]
+
+[node name="Cockpit" type="Node3D"]
+script = ExtResource("1_q5512")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_6fvvx")

--- a/faster-than-scrap/prefabs/modules/module_base.tscn
+++ b/faster-than-scrap/prefabs/modules/module_base.tscn
@@ -1,6 +1,11 @@
-[gd_scene load_steps=2 format=3 uid="uid://b66go7dtdv2m1"]
+[gd_scene load_steps=3 format=3 uid="uid://b66go7dtdv2m1"]
 
 [ext_resource type="Script" path="res://code/ship/modules/module.gd" id="1_if6ta"]
 
+[sub_resource type="SphereMesh" id="SphereMesh_8rabm"]
+
 [node name="ModuleBase" type="Node3D"]
 script = ExtResource("1_if6ta")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+mesh = SubResource("SphereMesh_8rabm")

--- a/faster-than-scrap/prefabs/ships/player_ship_example.tscn
+++ b/faster-than-scrap/prefabs/ships/player_ship_example.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=4 format=3 uid="uid://cpxkxwkuyh6l2"]
+
+[ext_resource type="Script" path="res://code/Player/player_ship.gd" id="1_ddodb"]
+[ext_resource type="PackedScene" uid="uid://3xoku32llsaa" path="res://prefabs/modules/cockpit.tscn" id="2_4lw14"]
+[ext_resource type="PackedScene" uid="uid://b66go7dtdv2m1" path="res://prefabs/modules/module_base.tscn" id="3_a4hie"]
+
+[node name="PlayerShipExample" type="Node3D" node_paths=PackedStringArray("cockpit", "modules")]
+script = ExtResource("1_ddodb")
+cockpit = NodePath("Cockpit")
+modules = [NodePath("Cockpit/ModuleBase"), NodePath("Cockpit/ModuleBase/ModuleBase"), NodePath("Cockpit/ModuleBase/ModuleBase/ModuleBase")]
+
+[node name="Cockpit" parent="." instance=ExtResource("2_4lw14")]
+
+[node name="ModuleBase" parent="Cockpit" instance=ExtResource("3_a4hie")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1.12175)
+
+[node name="ModuleBase" parent="Cockpit/ModuleBase" instance=ExtResource("3_a4hie")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.05367, 0, -0.0354288)
+
+[node name="ModuleBase" parent="Cockpit/ModuleBase/ModuleBase" instance=ExtResource("3_a4hie")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.2459, 0, -0.0354288)


### PR DESCRIPTION
added ship base class, player ship and cockpit module.

function on_game_change_state maybe should be moved to ship.

The idea is that ship should be a base class for enemy (for compatibility with weapons see #174 pr).

I am sure that player modules must be deactivated. The rest depends on enemy logic.