### PR TITLE
Fix player ship movement

### DIFF
--- a/faster-than-scrap/Sandbox/Surma/main.tscn
+++ b/faster-than-scrap/Sandbox/Surma/main.tscn
@@ -1,10 +1,7 @@
-[gd_scene load_steps=11 format=3 uid="uid://cjyrb2fperaxy"]
+[gd_scene load_steps=8 format=3 uid="uid://cjyrb2fperaxy"]
 
 [ext_resource type="PackedScene" uid="uid://kpc2w8wxljon" path="res://Sandbox/Surma/player.tscn" id="1_xdkxq"]
 [ext_resource type="PackedScene" uid="uid://rk0gm82fa8wn" path="res://Sandbox/Surma/prototype_enemy.tscn" id="2_ebm1s"]
-[ext_resource type="Script" path="res://Sandbox/Surma/player.gd" id="2_enufl"]
-[ext_resource type="Script" path="res://Sandbox/Surma/prototype_enemy.gd" id="3_7pljk"]
-[ext_resource type="Script" path="res://code/Player/player_ship.gd" id="3_i03m4"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_61bff"]
 sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
@@ -32,24 +29,13 @@ shadow_enabled = true
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource("Environment_wg0w7")
 
-[node name="Player" parent="." instance=ExtResource("1_xdkxq")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.00517011, 0, 0.494352)
-slide_on_ceiling = false
-floor_block_on_wall = false
-floor_snap_length = 0.0
-platform_on_leave = 2
-script = ExtResource("2_enufl")
-speed = 1500
-
-[node name="Camera3D" type="Camera3D" parent="Player"]
-transform = Transform3D(1, 0, 0, 0, 0.541517, 0.84069, 0, -0.84069, 0.541517, -0.00517011, 27.6107, 17.4563)
-
-[node name="Node" type="CharacterBody3D" parent="Player"]
-script = ExtResource("3_i03m4")
-
 [node name="PrototypeEnemy" parent="." instance=ExtResource("2_ebm1s")]
-transform = Transform3D(0.451796, 0, -0.892121, 0, 1, 0, 0.892121, 0, 0.451796, -33.9968, 1.52588e-05, -31.1474)
-script = ExtResource("3_7pljk")
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, -34.0862, 0, -30.0047)
+
+[node name="PlayerCharacterController" parent="." instance=ExtResource("1_xdkxq")]
+
+[node name="Camera3D" type="Camera3D" parent="PlayerCharacterController"]
+transform = Transform3D(1, 0, 0, 0, 0.541517, 0.84069, 0, -0.84069, 0.541517, 0, 27.6107, 17.9507)
 
 [node name="Station" type="CSGTorus3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -55.9555, 0, 2.40049)

--- a/faster-than-scrap/Sandbox/Surma/player.gd
+++ b/faster-than-scrap/Sandbox/Surma/player.gd
@@ -27,5 +27,4 @@ func _physics_process(delta: float) -> void:
 	controller.velocity.x = x * speed 
 	controller.velocity.y = 0
 	controller.velocity.z = y * speed 
-	print(controller.velocity)
 	controller.move_and_slide() # already takes delta into account

--- a/faster-than-scrap/Sandbox/Surma/player.gd
+++ b/faster-than-scrap/Sandbox/Surma/player.gd
@@ -1,17 +1,18 @@
-extends Ship
+extends PlayerShip
 
 @export var speed: int
 
+var controller: ShipController
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	pass  # Replace with function body.
+	await owner.ready
+	controller = owner as ShipController  # getting a typed reference to controlled ship
 
 
 # Called every frame. 'delta' ishe elapsed time since the previous frame.
 func _physics_process(delta: float) -> void:
 	var x = 0
-
 	var y = 0
 
 	if Input.is_key_pressed(KEY_A):
@@ -23,7 +24,8 @@ func _physics_process(delta: float) -> void:
 	if Input.is_key_pressed(KEY_S):
 		y = 1
 
-	velocity.x = x * speed * delta
-	velocity.y = 0
-	velocity.z = y * speed * delta
-	move_and_slide()
+	controller.velocity.x = x * speed 
+	controller.velocity.y = 0
+	controller.velocity.z = y * speed 
+	print(controller.velocity)
+	controller.move_and_slide() # already takes delta into account

--- a/faster-than-scrap/Sandbox/Surma/player.gd
+++ b/faster-than-scrap/Sandbox/Surma/player.gd
@@ -11,7 +11,7 @@ func _ready() -> void:
 
 
 # Called every frame. 'delta' ishe elapsed time since the previous frame.
-func _physics_process(delta: float) -> void:
+func _physics_process(_delta: float) -> void:
 	var x = 0
 	var y = 0
 
@@ -24,7 +24,7 @@ func _physics_process(delta: float) -> void:
 	if Input.is_key_pressed(KEY_S):
 		y = 1
 
-	controller.velocity.x = x * speed 
+	controller.velocity.x = x * speed
 	controller.velocity.y = 0
-	controller.velocity.z = y * speed 
+	controller.velocity.z = y * speed
 	controller.move_and_slide() # already takes delta into account

--- a/faster-than-scrap/Sandbox/Surma/player.tscn
+++ b/faster-than-scrap/Sandbox/Surma/player.tscn
@@ -8,7 +8,8 @@ floor_stop_on_slope = false
 script = ExtResource("1_u0ry0")
 ship = NodePath("Player")
 
-[node name="Player" type="Node3D" parent="."]
+[node name="Player" type="RigidBody3D" parent="."]
+gravity_scale = 0.0
 script = ExtResource("1_j12q1")
 speed = 16
 

--- a/faster-than-scrap/Sandbox/Surma/player.tscn
+++ b/faster-than-scrap/Sandbox/Surma/player.tscn
@@ -1,7 +1,16 @@
-[gd_scene format=3 uid="uid://kpc2w8wxljon"]
+[gd_scene load_steps=3 format=3 uid="uid://kpc2w8wxljon"]
 
-[node name="Player" type="CharacterBody3D" groups=["Player"]]
+[ext_resource type="Script" path="res://Sandbox/Surma/player.gd" id="1_j12q1"]
+[ext_resource type="Script" path="res://code/ship/ship_controller.gd" id="1_u0ry0"]
+
+[node name="PlayerCharacterController" type="CharacterBody3D" node_paths=PackedStringArray("ship") groups=["Player"]]
 floor_stop_on_slope = false
+script = ExtResource("1_u0ry0")
+ship = NodePath("Player")
+
+[node name="Player" type="Node3D" parent="."]
+script = ExtResource("1_j12q1")
+speed = 16
 
 [node name="CSGCombiner3D" type="CSGCombiner3D" parent="."]
 use_collision = true

--- a/faster-than-scrap/Sandbox/Surma/prototype_enemy.gd
+++ b/faster-than-scrap/Sandbox/Surma/prototype_enemy.gd
@@ -1,3 +1,3 @@
-extends Ship
+extends ShipController
 
 @export var speed := 16

--- a/faster-than-scrap/Sandbox/Surma/prototype_enemy.tscn
+++ b/faster-than-scrap/Sandbox/Surma/prototype_enemy.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=10 format=3 uid="uid://rk0gm82fa8wn"]
+[gd_scene load_steps=12 format=3 uid="uid://rk0gm82fa8wn"]
 
 [ext_resource type="Script" path="res://code/enemy/state_machine_npc.gd" id="1_6juta"]
+[ext_resource type="Script" path="res://Sandbox/Surma/prototype_enemy.gd" id="1_soqmw"]
+[ext_resource type="Script" path="res://code/ship/ship.gd" id="2_lvanf"]
 [ext_resource type="Script" path="res://code/enemy/states/aggressive.gd" id="2_ptaw0"]
 [ext_resource type="Script" path="res://code/enemy/transitions/transitionLowEnergy.gd" id="3_824ij"]
 [ext_resource type="Script" path="res://code/enemy/states/defensive.gd" id="3_qoxwt"]
@@ -12,8 +14,13 @@
 [sub_resource type="BoxShape3D" id="BoxShape3D_qicyb"]
 size = Vector3(2.14648, 1, 2.06055)
 
-[node name="PrototypeEnemy" type="CharacterBody3D"]
+[node name="PrototypeEnemy" type="CharacterBody3D" node_paths=PackedStringArray("ship")]
 transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 0, 0, 0)
+script = ExtResource("1_soqmw")
+ship = NodePath("Ship")
+
+[node name="Ship" type="Node3D" parent="."]
+script = ExtResource("2_lvanf")
 
 [node name="StateMachineEnemy" type="Node" parent="." node_paths=PackedStringArray("initial_state")]
 script = ExtResource("1_6juta")
@@ -24,7 +31,6 @@ script = ExtResource("2_ptaw0")
 
 [node name="LowEnergy" type="Node" parent="StateMachineEnemy/Aggressive" node_paths=PackedStringArray("new_state")]
 script = ExtResource("3_824ij")
-low_energy_treshold = null
 new_state = NodePath("../../Defensive")
 
 [node name="OutOfRange" type="Node" parent="StateMachineEnemy/Aggressive" node_paths=PackedStringArray("new_state")]

--- a/faster-than-scrap/Sandbox/Surma/prototype_enemy.tscn
+++ b/faster-than-scrap/Sandbox/Surma/prototype_enemy.tscn
@@ -19,7 +19,8 @@ transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 0, 0, 
 script = ExtResource("1_soqmw")
 ship = NodePath("Ship")
 
-[node name="Ship" type="Node3D" parent="."]
+[node name="Ship" type="RigidBody3D" parent="."]
+gravity_scale = 0.0
 script = ExtResource("2_lvanf")
 
 [node name="StateMachineEnemy" type="Node" parent="." node_paths=PackedStringArray("initial_state")]

--- a/faster-than-scrap/Sandbox/Wierzba/flyable_ship/build_ship_flyable.tscn
+++ b/faster-than-scrap/Sandbox/Wierzba/flyable_ship/build_ship_flyable.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://cpxkxwkuyh6l2" path="res://prefabs/ships/player_ship_example.tscn" id="2_marle"]
 [ext_resource type="PackedScene" uid="uid://taxlqo87sp7s" path="res://prefabs/modules/thruster.tscn" id="3_5rsdf"]
 [ext_resource type="Script" path="res://code/scene_loader.gd" id="4_v00nt"]
-[ext_resource type="PackedScene" path="res://prefabs/hud.tscn" id="5_abx51"]
+[ext_resource type="PackedScene" uid="uid://ckx4pgnacau0i" path="res://prefabs/hud.tscn" id="5_abx51"]
 
 [node name="BuildShip" type="Node3D"]
 
@@ -14,9 +14,8 @@ script = ExtResource("1_tic1n")
 [node name="Camera3D" type="Camera3D" parent="ShipBuilder"]
 transform = Transform3D(-1, -8.74228e-08, -3.82137e-15, 0, -4.37114e-08, 1, -8.74228e-08, 1, 4.37114e-08, 0, 5.135, 0)
 
-[node name="PlayerShipExample" parent="." node_paths=PackedStringArray("hud") instance=ExtResource("2_marle")]
+[node name="PlayerShipExample" parent="." instance=ExtResource("2_marle")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.99755, 0, 0)
-hud = NodePath("../MainCamera")
 
 [node name="Thruster" parent="." instance=ExtResource("3_5rsdf")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.44763, 0, -1.99791)
@@ -31,7 +30,6 @@ text = "Fly"
 [node name="SceneLoader" type="Node" parent="Button"]
 script = ExtResource("4_v00nt")
 
-[node name="MainCamera" parent="." node_paths=PackedStringArray("player_ship") instance=ExtResource("5_abx51")]
-player_ship = NodePath("../PlayerShipExample")
+[node name="MainCamera" parent="." instance=ExtResource("5_abx51")]
 
 [connection signal="pressed" from="Button" to="Button/SceneLoader" method="load_fly_ship_scene"]

--- a/faster-than-scrap/Sandbox/Wierzba/flyable_ship/fly_fly.tscn
+++ b/faster-than-scrap/Sandbox/Wierzba/flyable_ship/fly_fly.tscn
@@ -1,13 +1,17 @@
-[gd_scene load_steps=3 format=3 uid="uid://3t2jbpldv75a"]
+[gd_scene load_steps=4 format=3 uid="uid://3t2jbpldv75a"]
 
 [ext_resource type="PackedScene" uid="uid://creq1gbmemif6" path="res://prefabs/ships/flyable_ship.tscn" id="1_5iglw"]
-[ext_resource type="PackedScene" path="res://prefabs/hud.tscn" id="2_um6rh"]
+[ext_resource type="PackedScene" uid="uid://ckx4pgnacau0i" path="res://prefabs/hud.tscn" id="2_um6rh"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_eetof"]
 
 [node name="FlyFly" type="Node3D"]
 
-[node name="FlyableShip" parent="." node_paths=PackedStringArray("hud") instance=ExtResource("1_5iglw")]
-hud = NodePath("../MainCamera")
+[node name="FlyableShip" parent="." instance=ExtResource("1_5iglw")]
 
-[node name="MainCamera" parent="." node_paths=PackedStringArray("player_ship") instance=ExtResource("2_um6rh")]
+[node name="MainCamera" parent="." instance=ExtResource("2_um6rh")]
 transform = Transform3D(-1, 8.74228e-08, 3.82137e-15, 0, -4.37114e-08, 1, 8.74228e-08, 1, 4.37114e-08, 0, 10, 0)
-player_ship = NodePath("../FlyableShip")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.50015, 0, 0)
+mesh = SubResource("BoxMesh_eetof")

--- a/faster-than-scrap/code/Player/copy_position.gd
+++ b/faster-than-scrap/code/Player/copy_position.gd
@@ -1,9 +1,0 @@
-class_name CopyPosition
-
-extends Node3D
-
-@export var from:Node3D
-@export var offset:Vector3
-
-func _process(delta: float) -> void:
-	global_position = from.global_position + offset

--- a/faster-than-scrap/code/Player/copy_position.gd
+++ b/faster-than-scrap/code/Player/copy_position.gd
@@ -1,0 +1,9 @@
+class_name CopyPosition
+
+extends Node3D
+
+@export var from:Node3D
+@export var offset:Vector3
+
+func _process(delta: float) -> void:
+	global_position = from.global_position + offset

--- a/faster-than-scrap/code/enemy/states/aggressive.gd
+++ b/faster-than-scrap/code/enemy/states/aggressive.gd
@@ -10,4 +10,4 @@ func enter(_previous_state_path: String, _data := {}) -> void:
 
 func state_physics_update(_delta: float) -> void:
 	move_target_spotted(min_range_to_player, target)
-	controlled_ship.energy -= 0.5
+	ship_controller.ship.energy -= 0.5

--- a/faster-than-scrap/code/enemy/states/defensive.gd
+++ b/faster-than-scrap/code/enemy/states/defensive.gd
@@ -10,4 +10,4 @@ func enter(_previous_state_path: String, _data := {}) -> void:
 
 func state_physics_update(_delta: float) -> void:
 	move_target_spotted(min_range_to_player, target)
-	controlled_ship.energy += 0.5
+	ship_controller.ship.energy += 0.5

--- a/faster-than-scrap/code/enemy/states/state_npc.gd
+++ b/faster-than-scrap/code/enemy/states/state_npc.gd
@@ -9,7 +9,6 @@ var transitions: Array[baseTransition]
 func _ready() -> void:
 	await owner.ready
 	ship_controller = owner as ShipController  # getting a typed reference to controlled ship
-	var a = owner
 	assert(ship_controller != null, "The npc state needs the owner to be an npc node")
 
 	for transition: baseTransition in find_children("*", "baseTransition"):

--- a/faster-than-scrap/code/enemy/states/state_npc.gd
+++ b/faster-than-scrap/code/enemy/states/state_npc.gd
@@ -1,6 +1,6 @@
 class_name StateNPC extends State
 
-var controlled_ship: Ship
+var ship_controller: ShipController
 var transitions: Array[baseTransition]
 # player or another npc
 @onready var target: Ship
@@ -8,8 +8,9 @@ var transitions: Array[baseTransition]
 
 func _ready() -> void:
 	await owner.ready
-	controlled_ship = owner as Ship  # getting a typed reference to controlled ship
-	assert(controlled_ship != null, "The npc state needs the owner to be an npc node")
+	ship_controller = owner as ShipController  # getting a typed reference to controlled ship
+	var a = owner
+	assert(ship_controller != null, "The npc state needs the owner to be an npc node")
 
 	for transition: baseTransition in find_children("*", "baseTransition"):
 		transitions.append(transition)
@@ -19,7 +20,7 @@ func _ready() -> void:
 
 
 func move_target_spotted(min_range_to_player: int, target: Ship) -> void:
-	var vector_to_target = target.global_position - controlled_ship.global_position
+	var vector_to_target = target.global_position - ship_controller.global_position
 	var direction = vector_to_target.normalized()
 	var target_basis: Basis
 
@@ -30,6 +31,6 @@ func move_target_spotted(min_range_to_player: int, target: Ship) -> void:
 	#else:
 	#target_basis = Basis.looking_at(-1 * direction)
 
-	controlled_ship.basis = controlled_ship.basis.slerp(target_basis, 0.04)
-	controlled_ship.velocity = controlled_ship.speed * controlled_ship.basis.z * -1
-	controlled_ship.move_and_slide()
+	ship_controller.basis = ship_controller.basis.slerp(target_basis, 0.04)
+	ship_controller.velocity = ship_controller.speed * ship_controller.basis.z * -1
+	ship_controller.move_and_slide()

--- a/faster-than-scrap/code/enemy/transitions/inRange.gd
+++ b/faster-than-scrap/code/enemy/transitions/inRange.gd
@@ -4,6 +4,6 @@ extends baseTransition
 
 
 func condition() -> void:
-	var vector_to_target = target.global_position - controlled_ship.global_position
+	var vector_to_target = target.global_position - ship_controller.global_position
 	if vector_to_target.length() < range_treshold:
 		finished.emit(new_state.name)

--- a/faster-than-scrap/code/enemy/transitions/outOfRange.gd
+++ b/faster-than-scrap/code/enemy/transitions/outOfRange.gd
@@ -4,6 +4,6 @@ extends baseTransition
 
 
 func condition() -> void:
-	var vector_to_target = target.global_position - controlled_ship.global_position
+	var vector_to_target = target.global_position - ship_controller.ship.global_position
 	if vector_to_target.length() > range_treshold:
 		finished.emit(new_state.name)

--- a/faster-than-scrap/code/enemy/transitions/transitionHighEnergy.gd
+++ b/faster-than-scrap/code/enemy/transitions/transitionHighEnergy.gd
@@ -4,5 +4,5 @@ extends baseTransition
 
 
 func condition() -> void:
-	if controlled_ship.energy >= high_energy_treshold:
+	if ship_controller.ship.energy >= high_energy_treshold:
 		finished.emit(new_state.name)

--- a/faster-than-scrap/code/enemy/transitions/transitionLowEnergy.gd
+++ b/faster-than-scrap/code/enemy/transitions/transitionLowEnergy.gd
@@ -4,5 +4,5 @@ extends baseTransition
 
 
 func condition() -> void:
-	if controlled_ship.energy < low_energy_treshold:
+	if ship_controller.ship.energy < low_energy_treshold:
 		finished.emit(new_state.name)

--- a/faster-than-scrap/code/ship/modules/module.gd
+++ b/faster-than-scrap/code/ship/modules/module.gd
@@ -89,7 +89,9 @@ func on_key_change(key: Key) -> void:
 	if(label != null):
 		label.text = text
 		## one line text up to 3 characters
-		if text.length() > 0 and text.length() <= 3:
+		if text.length() <= 0:
+			return
+		if text.length() <= 3:
 			label.font_size = 160/text.length()
 		else:
 			label.font_size = 160/text.length() * 2

--- a/faster-than-scrap/code/ship/ship.gd
+++ b/faster-than-scrap/code/ship/ship.gd
@@ -1,6 +1,6 @@
 class_name Ship
 
-extends CharacterBody3D
+extends Node3D
 
 ## Base class for player and enemy
 

--- a/faster-than-scrap/code/ship/ship.gd
+++ b/faster-than-scrap/code/ship/ship.gd
@@ -1,6 +1,6 @@
 class_name Ship
 
-extends Node3D
+extends RigidBody3D
 
 ## Base class for player and enemy
 

--- a/faster-than-scrap/code/ship/ship_controller.gd
+++ b/faster-than-scrap/code/ship/ship_controller.gd
@@ -1,0 +1,9 @@
+class_name ShipController
+
+extends CharacterBody3D
+
+## class used mostly for enemy to allow compatibility
+## with player implementation and to allow CharacteroBody3D
+## control of the enemy.
+
+@export var ship: Ship

--- a/faster-than-scrap/prefabs/ships/flyable_ship.tscn
+++ b/faster-than-scrap/prefabs/ships/flyable_ship.tscn
@@ -1,33 +1,28 @@
-[gd_scene load_steps=6 format=3 uid="uid://creq1gbmemif6"]
+[gd_scene load_steps=5 format=3 uid="uid://creq1gbmemif6"]
 
 [ext_resource type="Script" path="res://code/Player/player_ship.gd" id="1_keeht"]
 [ext_resource type="PackedScene" uid="uid://dqaprpym1uev" path="res://prefabs/modules/cockpit.tscn" id="1_odfy5"]
 [ext_resource type="PackedScene" uid="uid://b66go7dtdv2m1" path="res://prefabs/modules/module_base.tscn" id="2_eda7p"]
-[ext_resource type="Script" path="res://code/Player/copy_position.gd" id="2_tyssn"]
 [ext_resource type="PackedScene" uid="uid://taxlqo87sp7s" path="res://prefabs/modules/thruster.tscn" id="3_ymjaj"]
 
-[node name="FlyableShip" type="Node3D" node_paths=PackedStringArray("cockpit", "modules")]
+[node name="FlyableShip" type="RigidBody3D" node_paths=PackedStringArray("cockpit", "modules")]
+gravity_scale = 0.0
 script = ExtResource("1_keeht")
 cockpit = NodePath("Cockpit")
-modules = [NodePath("Cockpit"), NodePath("RigidBody3D"), NodePath("RigidBody3D/Thruster Forward"), NodePath("RigidBody3D2"), NodePath("RigidBody3D3")]
+modules = [NodePath("Cockpit"), NodePath("Cockpit/RigidBody3D"), NodePath("Cockpit/RigidBody3D/Thruster Forward"), NodePath("Cockpit/RigidBody3D/RigidBody3D2"), NodePath("Cockpit/RigidBody3D/RigidBody3D3")]
 
-[node name="CopyPosition" type="Node3D" parent="." node_paths=PackedStringArray("from")]
-script = ExtResource("2_tyssn")
-from = NodePath("../Cockpit")
-
-[node name="PlayerShip" type="Node3D" parent="CopyPosition" node_paths=PackedStringArray("cockpit", "modules")]
-script = ExtResource("1_keeht")
-cockpit = NodePath("../../Cockpit")
-modules = [NodePath("../../Cockpit"), NodePath("../../Cockpit/Thruster Backward"), NodePath("../../Cockpit/Thruster Right"), NodePath("../../Cockpit/Thruster Left"), NodePath("../../RigidBody3D"), NodePath("../../RigidBody3D/Thruster Forward"), NodePath("../../RigidBody3D2"), NodePath("../../RigidBody3D3")]
+[node name="Generic6DOFJoint3D" type="Generic6DOFJoint3D" parent="."]
+node_a = NodePath("..")
+node_b = NodePath("../Cockpit")
 
 [node name="Cockpit" parent="." node_paths=PackedStringArray("ship") instance=ExtResource("1_odfy5")]
-ship = NodePath("../CopyPosition/PlayerShip")
+ship = NodePath("..")
 
 [node name="Thruster Backward" parent="Cockpit" node_paths=PackedStringArray("ship") instance=ExtResource("3_ymjaj")]
 transform = Transform3D(-1, 0, 7.54979e-08, 0, 1, 0, -7.54979e-08, 0, -1, -0.0145017, 0, 1.61053)
 recoil_force = 1000.0
 activation_key = 83
-ship = NodePath("../../CopyPosition/PlayerShip")
+ship = NodePath("../..")
 
 [node name="PinJoint3D" type="Generic6DOFJoint3D" parent="Cockpit/Thruster Backward"]
 transform = Transform3D(-1, 0, -7.54979e-08, 0, 1, 0, 7.54979e-08, 0, -1, -0.0145016, 0, 1.61053)
@@ -38,7 +33,7 @@ node_b = NodePath("..")
 transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 1.56632, 0, 2.0007)
 recoil_force = 1000.0
 activation_key = 68
-ship = NodePath("../../CopyPosition/PlayerShip")
+ship = NodePath("../..")
 
 [node name="PinJoint3D2" type="Generic6DOFJoint3D" parent="Cockpit/Thruster Right"]
 transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, -2.0007, 0, 1.56632)
@@ -49,47 +44,47 @@ node_b = NodePath("..")
 transform = Transform3D(1.19209e-07, 0, 1, 0, 1, 0, -1, 0, 1.19209e-07, -1.66784, 0, 2.0007)
 recoil_force = 1000.0
 activation_key = 65
-ship = NodePath("../../CopyPosition/PlayerShip")
+ship = NodePath("../..")
 
 [node name="PinJoint3D3" type="Generic6DOFJoint3D" parent="Cockpit/Thruster Left"]
 transform = Transform3D(1.19209e-07, 0, -1, 0, 1, 0, 1, 0, 1.19209e-07, 2.0007, 0, 1.66784)
 node_a = NodePath("../..")
 node_b = NodePath("..")
 
-[node name="RigidBody3D" parent="." node_paths=PackedStringArray("ship") instance=ExtResource("2_eda7p")]
+[node name="RigidBody3D" parent="Cockpit" node_paths=PackedStringArray("ship") instance=ExtResource("2_eda7p")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -1.39162)
-ship = NodePath("../CopyPosition/PlayerShip")
+ship = NodePath("../..")
 
-[node name="Thruster Forward" parent="RigidBody3D" node_paths=PackedStringArray("ship") instance=ExtResource("3_ymjaj")]
+[node name="Thruster Forward" parent="Cockpit/RigidBody3D" node_paths=PackedStringArray("ship") instance=ExtResource("3_ymjaj")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -1.50827)
 recoil_force = 1000.0
 activation_key = 87
-ship = NodePath("../../CopyPosition/PlayerShip")
+ship = NodePath("../../..")
 
-[node name="PinJoint3D" type="Generic6DOFJoint3D" parent="RigidBody3D/Thruster Forward"]
+[node name="PinJoint3D" type="Generic6DOFJoint3D" parent="Cockpit/RigidBody3D/Thruster Forward"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1.50827)
 node_a = NodePath("../..")
 node_b = NodePath("..")
 
-[node name="PinJoint3D" type="Generic6DOFJoint3D" parent="RigidBody3D"]
+[node name="PinJoint3D" type="Generic6DOFJoint3D" parent="Cockpit/RigidBody3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1.39162)
-node_a = NodePath("../../Cockpit")
+node_a = NodePath("../..")
 node_b = NodePath("..")
 
-[node name="RigidBody3D2" parent="." node_paths=PackedStringArray("ship") instance=ExtResource("2_eda7p")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.37863, 0, -1.37221)
-ship = NodePath("../CopyPosition/PlayerShip")
+[node name="RigidBody3D2" parent="Cockpit/RigidBody3D" node_paths=PackedStringArray("ship") instance=ExtResource("2_eda7p")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.37863, 0, 0.01941)
+ship = NodePath("../../..")
 
-[node name="PinJoint3D2" type="Generic6DOFJoint3D" parent="RigidBody3D2"]
+[node name="PinJoint3D2" type="Generic6DOFJoint3D" parent="Cockpit/RigidBody3D/RigidBody3D2"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.37863, 0, 1.37221)
-node_a = NodePath("../../Cockpit")
+node_a = NodePath("../../..")
 node_b = NodePath("..")
 
-[node name="RigidBody3D3" parent="." node_paths=PackedStringArray("ship") instance=ExtResource("2_eda7p")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.63062, 0, -1.34398)
-ship = NodePath("../CopyPosition/PlayerShip")
+[node name="RigidBody3D3" parent="Cockpit/RigidBody3D" node_paths=PackedStringArray("ship") instance=ExtResource("2_eda7p")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.63062, 0, 0.0476401)
+ship = NodePath("../../..")
 
-[node name="PinJoint3D3" type="Generic6DOFJoint3D" parent="RigidBody3D3"]
+[node name="PinJoint3D3" type="Generic6DOFJoint3D" parent="Cockpit/RigidBody3D/RigidBody3D3"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.63062, 0, 1.34398)
-node_a = NodePath("../../Cockpit")
+node_a = NodePath("../../..")
 node_b = NodePath("..")

--- a/faster-than-scrap/prefabs/ships/flyable_ship.tscn
+++ b/faster-than-scrap/prefabs/ships/flyable_ship.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=5 format=3 uid="uid://creq1gbmemif6"]
+[gd_scene load_steps=6 format=3 uid="uid://creq1gbmemif6"]
 
 [ext_resource type="Script" path="res://code/Player/player_ship.gd" id="1_keeht"]
 [ext_resource type="PackedScene" uid="uid://dqaprpym1uev" path="res://prefabs/modules/cockpit.tscn" id="1_odfy5"]
 [ext_resource type="PackedScene" uid="uid://b66go7dtdv2m1" path="res://prefabs/modules/module_base.tscn" id="2_eda7p"]
+[ext_resource type="Script" path="res://code/Player/copy_position.gd" id="2_tyssn"]
 [ext_resource type="PackedScene" uid="uid://taxlqo87sp7s" path="res://prefabs/modules/thruster.tscn" id="3_ymjaj"]
 
 [node name="FlyableShip" type="Node3D" node_paths=PackedStringArray("cockpit", "modules")]
@@ -10,14 +11,23 @@ script = ExtResource("1_keeht")
 cockpit = NodePath("Cockpit")
 modules = [NodePath("Cockpit"), NodePath("RigidBody3D"), NodePath("RigidBody3D/Thruster Forward"), NodePath("RigidBody3D2"), NodePath("RigidBody3D3")]
 
+[node name="CopyPosition" type="Node3D" parent="." node_paths=PackedStringArray("from")]
+script = ExtResource("2_tyssn")
+from = NodePath("../Cockpit")
+
+[node name="PlayerShip" type="Node3D" parent="CopyPosition" node_paths=PackedStringArray("cockpit", "modules")]
+script = ExtResource("1_keeht")
+cockpit = NodePath("../../Cockpit")
+modules = [NodePath("../../Cockpit"), NodePath("../../Cockpit/Thruster Backward"), NodePath("../../Cockpit/Thruster Right"), NodePath("../../Cockpit/Thruster Left"), NodePath("../../RigidBody3D"), NodePath("../../RigidBody3D/Thruster Forward"), NodePath("../../RigidBody3D2"), NodePath("../../RigidBody3D3")]
+
 [node name="Cockpit" parent="." node_paths=PackedStringArray("ship") instance=ExtResource("1_odfy5")]
-ship = NodePath("..")
+ship = NodePath("../CopyPosition/PlayerShip")
 
 [node name="Thruster Backward" parent="Cockpit" node_paths=PackedStringArray("ship") instance=ExtResource("3_ymjaj")]
 transform = Transform3D(-1, 0, 7.54979e-08, 0, 1, 0, -7.54979e-08, 0, -1, -0.0145017, 0, 1.61053)
 recoil_force = 1000.0
 activation_key = 83
-ship = NodePath("../..")
+ship = NodePath("../../CopyPosition/PlayerShip")
 
 [node name="PinJoint3D" type="Generic6DOFJoint3D" parent="Cockpit/Thruster Backward"]
 transform = Transform3D(-1, 0, -7.54979e-08, 0, 1, 0, 7.54979e-08, 0, -1, -0.0145016, 0, 1.61053)
@@ -28,7 +38,7 @@ node_b = NodePath("..")
 transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 1.56632, 0, 2.0007)
 recoil_force = 1000.0
 activation_key = 68
-ship = NodePath("../..")
+ship = NodePath("../../CopyPosition/PlayerShip")
 
 [node name="PinJoint3D2" type="Generic6DOFJoint3D" parent="Cockpit/Thruster Right"]
 transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, -2.0007, 0, 1.56632)
@@ -39,7 +49,7 @@ node_b = NodePath("..")
 transform = Transform3D(1.19209e-07, 0, 1, 0, 1, 0, -1, 0, 1.19209e-07, -1.66784, 0, 2.0007)
 recoil_force = 1000.0
 activation_key = 65
-ship = NodePath("../..")
+ship = NodePath("../../CopyPosition/PlayerShip")
 
 [node name="PinJoint3D3" type="Generic6DOFJoint3D" parent="Cockpit/Thruster Left"]
 transform = Transform3D(1.19209e-07, 0, -1, 0, 1, 0, 1, 0, 1.19209e-07, 2.0007, 0, 1.66784)
@@ -48,13 +58,13 @@ node_b = NodePath("..")
 
 [node name="RigidBody3D" parent="." node_paths=PackedStringArray("ship") instance=ExtResource("2_eda7p")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -1.39162)
-ship = NodePath("..")
+ship = NodePath("../CopyPosition/PlayerShip")
 
 [node name="Thruster Forward" parent="RigidBody3D" node_paths=PackedStringArray("ship") instance=ExtResource("3_ymjaj")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -1.50827)
 recoil_force = 1000.0
 activation_key = 87
-ship = NodePath("../..")
+ship = NodePath("../../CopyPosition/PlayerShip")
 
 [node name="PinJoint3D" type="Generic6DOFJoint3D" parent="RigidBody3D/Thruster Forward"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1.50827)
@@ -68,7 +78,7 @@ node_b = NodePath("..")
 
 [node name="RigidBody3D2" parent="." node_paths=PackedStringArray("ship") instance=ExtResource("2_eda7p")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.37863, 0, -1.37221)
-ship = NodePath("..")
+ship = NodePath("../CopyPosition/PlayerShip")
 
 [node name="PinJoint3D2" type="Generic6DOFJoint3D" parent="RigidBody3D2"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.37863, 0, 1.37221)
@@ -77,7 +87,7 @@ node_b = NodePath("..")
 
 [node name="RigidBody3D3" parent="." node_paths=PackedStringArray("ship") instance=ExtResource("2_eda7p")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.63062, 0, -1.34398)
-ship = NodePath("..")
+ship = NodePath("../CopyPosition/PlayerShip")
 
 [node name="PinJoint3D3" type="Generic6DOFJoint3D" parent="RigidBody3D3"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.63062, 0, 1.34398)


### PR DESCRIPTION
Minor fix to #218 and #129 

Now root of the flyable ship (PlayerShip script) is moving with the rest of the ship.
Changed slightly for compatibility so that the Playership which uses modules to move works with the ship which is controlled by CharacterBody3D -> so the shipController is added which is an overlay for the normal ship to move it freely.

Minor fix do not print text when module button is null