### PR TITLE
Game manager scene

### DIFF
--- a/faster-than-scrap/code/Singletons/game_manager.gd
+++ b/faster-than-scrap/code/Singletons/game_manager.gd
@@ -6,8 +6,9 @@ extends Node
 
 signal new_game_state
 
-@export var game_state :GameState.State = GameState.State.FLY
-@export var player_ship: PlayerShip
+@export var game_state: GameState.State = GameState.State.FLY
+
+var player_ship: PlayerShip
 
 
 # Called when the node enters the scene tree for the first time.
@@ -16,7 +17,7 @@ func _ready() -> void:
 
 
 func set_game_state(new_state: GameState.State) -> void:
-	game_state=new_state
+	game_state = new_state
 	new_game_state.emit(new_state)
 	# future logic for changing state
 	match new_state:
@@ -31,8 +32,10 @@ func set_game_state(new_state: GameState.State) -> void:
 		GameState.State.MAIN_MENU:
 			_unpause_entities()
 
+
 func _pause_entities():
 	get_tree().paused = true
+
 
 func _unpause_entities():
 	get_tree().paused = false

--- a/faster-than-scrap/prefabs/game_manager.tscn
+++ b/faster-than-scrap/prefabs/game_manager.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://bpgm8wx8t3cxu"]
+
+[ext_resource type="Script" path="res://code/Singletons/game_manager.gd" id="1_vvpif"]
+
+[node name="GameManager" type="Node"]
+script = ExtResource("1_vvpif")

--- a/faster-than-scrap/project.godot
+++ b/faster-than-scrap/project.godot
@@ -17,7 +17,7 @@ config/icon="res://icon.svg"
 
 [autoload]
 
-GameManager="*res://code/Singletons/game_manager.gd"
+GameManager="*res://prefabs/game_manager.tscn"
 
 [display]
 


### PR DESCRIPTION
- created GameManager scene
- in game_manager.gd removed `@export` for `player_ship` variable, as it will always be set by other scripts, not in the editor

Autoloading GameManager as a scene and not as a script allows the access to it's `@export` fields from the editor (by editing the game manager scene). Apart from that, everything else is unchanged