### PR TITLE
Model Prefabs

### DIFF
--- a/faster-than-scrap/Sandbox/Lukas/filip_l_sandbox.tscn
+++ b/faster-than-scrap/Sandbox/Lukas/filip_l_sandbox.tscn
@@ -1,33 +1,3 @@
-[gd_scene load_steps=8 format=3 uid="uid://cxk4lnel5f1yq"]
-
-[ext_resource type="ArrayMesh" uid="uid://j5ivenwvt2cm" path="res://art/Models/bumper/bumper_collider.obj" id="1_t8j05"]
-[ext_resource type="Material" uid="uid://bwp45lr0j6av" path="res://art/materials/bumper/bumper_material_3d.tres" id="2_mv6jx"]
-[ext_resource type="ArrayMesh" uid="uid://ck4gqd8vg7qxw" path="res://art/Models/bumper/bumper.obj" id="3_67tvg"]
-[ext_resource type="PackedScene" uid="uid://bewasbmybcuql" path="res://art/Models/bumper/bumper_collision_shape_3d.tscn" id="4_aaom6"]
-[ext_resource type="Material" uid="uid://css7je76l8eb7" path="res://art/materials/cabin/cabin_material_3d.tres" id="5_rx6co"]
-[ext_resource type="ArrayMesh" uid="uid://d3jn6wcbnxlbs" path="res://art/Models/cabin/Cabin_Model.obj" id="6_3kywj"]
-[ext_resource type="PackedScene" uid="uid://b670jj7lnajsd" path="res://prefabs/environment/space_environment.tscn" id="7_xfsf1"]
+[gd_scene format=3 uid="uid://cxk4lnel5f1yq"]
 
 [node name="FilipLSandbox" type="Node3D"]
-
-[node name="BumperCollider" type="MeshInstance3D" parent="."]
-visible = false
-mesh = ExtResource("1_t8j05")
-
-[node name="Bumper" type="MeshInstance3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.5243, 0, 0)
-material_override = ExtResource("2_mv6jx")
-mesh = ExtResource("3_67tvg")
-
-[node name="BumperCollider2" type="MeshInstance3D" parent="."]
-visible = false
-mesh = ExtResource("1_t8j05")
-
-[node name="BumperCollisionShape3D" parent="." instance=ExtResource("4_aaom6")]
-visible = false
-
-[node name="CabinModel" type="MeshInstance3D" parent="."]
-material_override = ExtResource("5_rx6co")
-mesh = ExtResource("6_3kywj")
-
-[node name="SpaceEnvironment" parent="." instance=ExtResource("7_xfsf1")]

--- a/faster-than-scrap/art/Models/Shield.obj.import
+++ b/faster-than-scrap/art/Models/Shield.obj.import
@@ -4,14 +4,14 @@ importer="wavefront_obj"
 importer_version=1
 type="Mesh"
 uid="uid://cadsh5rgfnp6t"
-path="res://.godot/imported/Shield.obj-8fe6844c2953ae1372564df3b77acafc.mesh"
+path="res://.godot/imported/Shield.obj-a8a38eee6fd716f6770ac7dee9f72f8c.mesh"
 
 [deps]
 
-files=["res://.godot/imported/Shield.obj-8fe6844c2953ae1372564df3b77acafc.mesh"]
+files=["res://.godot/imported/Shield.obj-a8a38eee6fd716f6770ac7dee9f72f8c.mesh"]
 
-source_file="res://art/Models/Shield.obj"
-dest_files=["res://.godot/imported/Shield.obj-8fe6844c2953ae1372564df3b77acafc.mesh", "res://.godot/imported/Shield.obj-8fe6844c2953ae1372564df3b77acafc.mesh"]
+source_file="res://art/models/Shield.obj"
+dest_files=["res://.godot/imported/Shield.obj-a8a38eee6fd716f6770ac7dee9f72f8c.mesh", "res://.godot/imported/Shield.obj-a8a38eee6fd716f6770ac7dee9f72f8c.mesh"]
 
 [params]
 

--- a/faster-than-scrap/art/Models/bumper/bumper.obj.import
+++ b/faster-than-scrap/art/Models/bumper/bumper.obj.import
@@ -4,14 +4,14 @@ importer="wavefront_obj"
 importer_version=1
 type="Mesh"
 uid="uid://ck4gqd8vg7qxw"
-path="res://.godot/imported/bumper.obj-276ebfe36c31f6cd78d10cc6a0256d71.mesh"
+path="res://.godot/imported/bumper.obj-be7cd1c7ac015eec2636cd527a285af9.mesh"
 
 [deps]
 
-files=["res://.godot/imported/bumper.obj-276ebfe36c31f6cd78d10cc6a0256d71.mesh"]
+files=["res://.godot/imported/bumper.obj-be7cd1c7ac015eec2636cd527a285af9.mesh"]
 
-source_file="res://art/Models/bumper/bumper.obj"
-dest_files=["res://.godot/imported/bumper.obj-276ebfe36c31f6cd78d10cc6a0256d71.mesh", "res://.godot/imported/bumper.obj-276ebfe36c31f6cd78d10cc6a0256d71.mesh"]
+source_file="res://art/models/bumper/bumper.obj"
+dest_files=["res://.godot/imported/bumper.obj-be7cd1c7ac015eec2636cd527a285af9.mesh", "res://.godot/imported/bumper.obj-be7cd1c7ac015eec2636cd527a285af9.mesh"]
 
 [params]
 

--- a/faster-than-scrap/art/Models/bumper/bumper_collider.obj.import
+++ b/faster-than-scrap/art/Models/bumper/bumper_collider.obj.import
@@ -4,14 +4,14 @@ importer="wavefront_obj"
 importer_version=1
 type="Mesh"
 uid="uid://j5ivenwvt2cm"
-path="res://.godot/imported/bumper_collider.obj-7d9d816bf3cd83bed362c7e5b9596e1f.mesh"
+path="res://.godot/imported/bumper_collider.obj-1521d484b04228d07295286fd413eff5.mesh"
 
 [deps]
 
-files=["res://.godot/imported/bumper_collider.obj-7d9d816bf3cd83bed362c7e5b9596e1f.mesh"]
+files=["res://.godot/imported/bumper_collider.obj-1521d484b04228d07295286fd413eff5.mesh"]
 
-source_file="res://art/Models/bumper/bumper_collider.obj"
-dest_files=["res://.godot/imported/bumper_collider.obj-7d9d816bf3cd83bed362c7e5b9596e1f.mesh", "res://.godot/imported/bumper_collider.obj-7d9d816bf3cd83bed362c7e5b9596e1f.mesh"]
+source_file="res://art/models/bumper/bumper_collider.obj"
+dest_files=["res://.godot/imported/bumper_collider.obj-1521d484b04228d07295286fd413eff5.mesh", "res://.godot/imported/bumper_collider.obj-1521d484b04228d07295286fd413eff5.mesh"]
 
 [params]
 

--- a/faster-than-scrap/art/Models/bumper_wide/bumper.obj.import
+++ b/faster-than-scrap/art/Models/bumper_wide/bumper.obj.import
@@ -4,14 +4,14 @@ importer="wavefront_obj"
 importer_version=1
 type="Mesh"
 uid="uid://bg4jdtf51j1tf"
-path="res://.godot/imported/bumper.obj-f5f4e9f95b91af9eaf9c43ed15e8907f.mesh"
+path="res://.godot/imported/bumper.obj-4698bfd36fde1ce544c8806414c1f879.mesh"
 
 [deps]
 
-files=["res://.godot/imported/bumper.obj-f5f4e9f95b91af9eaf9c43ed15e8907f.mesh"]
+files=["res://.godot/imported/bumper.obj-4698bfd36fde1ce544c8806414c1f879.mesh"]
 
-source_file="res://art/Models/bumper_wide/bumper.obj"
-dest_files=["res://.godot/imported/bumper.obj-f5f4e9f95b91af9eaf9c43ed15e8907f.mesh", "res://.godot/imported/bumper.obj-f5f4e9f95b91af9eaf9c43ed15e8907f.mesh"]
+source_file="res://art/models/bumper_wide/bumper.obj"
+dest_files=["res://.godot/imported/bumper.obj-4698bfd36fde1ce544c8806414c1f879.mesh", "res://.godot/imported/bumper.obj-4698bfd36fde1ce544c8806414c1f879.mesh"]
 
 [params]
 

--- a/faster-than-scrap/art/Models/bumper_wide/bumper_collider.obj.import
+++ b/faster-than-scrap/art/Models/bumper_wide/bumper_collider.obj.import
@@ -4,14 +4,14 @@ importer="wavefront_obj"
 importer_version=1
 type="Mesh"
 uid="uid://b43ayffj45a0q"
-path="res://.godot/imported/bumper_collider.obj-7948bbf59b52a37cfa911a75fee60034.mesh"
+path="res://.godot/imported/bumper_collider.obj-3481e37b82eac4c260bde80e749456f5.mesh"
 
 [deps]
 
-files=["res://.godot/imported/bumper_collider.obj-7948bbf59b52a37cfa911a75fee60034.mesh"]
+files=["res://.godot/imported/bumper_collider.obj-3481e37b82eac4c260bde80e749456f5.mesh"]
 
-source_file="res://art/Models/bumper_wide/bumper_collider.obj"
-dest_files=["res://.godot/imported/bumper_collider.obj-7948bbf59b52a37cfa911a75fee60034.mesh", "res://.godot/imported/bumper_collider.obj-7948bbf59b52a37cfa911a75fee60034.mesh"]
+source_file="res://art/models/bumper_wide/bumper_collider.obj"
+dest_files=["res://.godot/imported/bumper_collider.obj-3481e37b82eac4c260bde80e749456f5.mesh", "res://.godot/imported/bumper_collider.obj-3481e37b82eac4c260bde80e749456f5.mesh"]
 
 [params]
 

--- a/faster-than-scrap/art/model_prefabs/bumper_model_pf.tscn
+++ b/faster-than-scrap/art/model_prefabs/bumper_model_pf.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://c6hixpni6xar4"]
+
+[ext_resource type="Material" uid="uid://bwp45lr0j6av" path="res://art/materials/bumper/bumper_material_3d.tres" id="1_gg0ts"]
+[ext_resource type="ArrayMesh" uid="uid://ck4gqd8vg7qxw" path="res://art/models/bumper/bumper.obj" id="2_vlmq5"]
+
+[node name="BumperModel" type="Node3D"]
+
+[node name="Bumper" type="MeshInstance3D" parent="."]
+material_override = ExtResource("1_gg0ts")
+mesh = ExtResource("2_vlmq5")

--- a/faster-than-scrap/art/model_prefabs/bumper_wide_model_pf.tscn
+++ b/faster-than-scrap/art/model_prefabs/bumper_wide_model_pf.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://dkdilbsdwigdf"]
+
+[ext_resource type="Material" uid="uid://dwb3vte80n530" path="res://art/materials/bumper_wide/bumper_wide_material_3d.tres" id="1_6glbb"]
+[ext_resource type="ArrayMesh" uid="uid://bg4jdtf51j1tf" path="res://art/models/bumper_wide/bumper.obj" id="2_ss1it"]
+
+[node name="BumperWideModel" type="Node3D"]
+
+[node name="BumperWide" type="MeshInstance3D" parent="."]
+material_override = ExtResource("1_6glbb")
+mesh = ExtResource("2_ss1it")

--- a/faster-than-scrap/art/model_prefabs/cabin_model_pf.tscn
+++ b/faster-than-scrap/art/model_prefabs/cabin_model_pf.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://dtvhl0ltls65a"]
+
+[ext_resource type="Material" uid="uid://css7je76l8eb7" path="res://art/materials/cabin/cabin_material_3d.tres" id="1_jdx4k"]
+[ext_resource type="ArrayMesh" uid="uid://d3jn6wcbnxlbs" path="res://art/models/cabin/Cabin_Model.obj" id="2_qaxvn"]
+
+[node name="CabinModel" type="Node3D"]
+
+[node name="CabinModel" type="MeshInstance3D" parent="."]
+material_override = ExtResource("1_jdx4k")
+mesh = ExtResource("2_qaxvn")

--- a/faster-than-scrap/art/model_prefabs/common_gun_model_pf.tscn
+++ b/faster-than-scrap/art/model_prefabs/common_gun_model_pf.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://dwlfvellnrf75"]
+
+[ext_resource type="Material" uid="uid://ba5cisvxw5t1" path="res://art/materials/common_gun/common_gun_material_3d.tres" id="1_mqsuj"]
+[ext_resource type="ArrayMesh" uid="uid://lwlx588xi1eg" path="res://art/models/common_gun/common_gun.obj" id="2_srtb4"]
+
+[node name="CommonGunModel" type="Node3D"]
+
+[node name="CommonGun" type="MeshInstance3D" parent="."]
+material_override = ExtResource("1_mqsuj")
+mesh = ExtResource("2_srtb4")

--- a/faster-than-scrap/art/model_prefabs/frame_0_model_pf.tscn
+++ b/faster-than-scrap/art/model_prefabs/frame_0_model_pf.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://bijtikg2etao2"]
+
+[ext_resource type="Material" uid="uid://u2jcla7cl0d0" path="res://art/materials/frame/frame_material_3d.tres" id="1_vavoo"]
+[ext_resource type="ArrayMesh" uid="uid://dyggmpc21gmcw" path="res://art/models/frame/frame.obj" id="2_8nu0h"]
+
+[node name="Frame0Model" type="Node3D"]
+
+[node name="Frame0" type="MeshInstance3D" parent="."]
+material_override = ExtResource("1_vavoo")
+mesh = ExtResource("2_8nu0h")

--- a/faster-than-scrap/art/model_prefabs/frame_1_model_pf.tscn
+++ b/faster-than-scrap/art/model_prefabs/frame_1_model_pf.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://hfaxy86ad8gt"]
+
+[ext_resource type="Material" uid="uid://cqu6fkku70tof" path="res://art/materials/frame1/frame1_material_3d.tres" id="1_8xngs"]
+[ext_resource type="ArrayMesh" uid="uid://ilin5br3b8v2" path="res://art/models/frame1/frame1.obj" id="2_dujt1"]
+
+[node name="Frame1Model" type="Node3D"]
+
+[node name="Frame1" type="MeshInstance3D" parent="."]
+material_override = ExtResource("1_8xngs")
+mesh = ExtResource("2_dujt1")

--- a/faster-than-scrap/art/model_prefabs/thruster_model_pf.tscn
+++ b/faster-than-scrap/art/model_prefabs/thruster_model_pf.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://cybvhv36ih1j6"]
+
+[ext_resource type="Material" uid="uid://bbmx3djnt7c0u" path="res://art/materials/thruster/thruster_material_3d.tres" id="1_nif0b"]
+[ext_resource type="ArrayMesh" uid="uid://bfla2gv2cw50c" path="res://art/models/thruster/thruster.obj" id="2_bfwmp"]
+
+[node name="ThrusterModel" type="Node3D"]
+
+[node name="Thruster" type="MeshInstance3D" parent="."]
+material_override = ExtResource("1_nif0b")
+mesh = ExtResource("2_bfwmp")

--- a/faster-than-scrap/art/models/cabin/Cabin_Colider.obj.import
+++ b/faster-than-scrap/art/models/cabin/Cabin_Colider.obj.import
@@ -4,14 +4,14 @@ importer="wavefront_obj"
 importer_version=1
 type="Mesh"
 uid="uid://2cce3frwwg3d"
-path="res://.godot/imported/Cabin_Colider.obj-f8cc9fc82c259e85b0bdd1135cd2bb03.mesh"
+path="res://.godot/imported/Cabin_Colider.obj-0ee3a0660d8f35f2f503363253ad10fa.mesh"
 
 [deps]
 
-files=["res://.godot/imported/Cabin_Colider.obj-f8cc9fc82c259e85b0bdd1135cd2bb03.mesh"]
+files=["res://.godot/imported/Cabin_Colider.obj-0ee3a0660d8f35f2f503363253ad10fa.mesh"]
 
-source_file="res://art/Models/cabin/Cabin_Colider.obj"
-dest_files=["res://.godot/imported/Cabin_Colider.obj-f8cc9fc82c259e85b0bdd1135cd2bb03.mesh", "res://.godot/imported/Cabin_Colider.obj-f8cc9fc82c259e85b0bdd1135cd2bb03.mesh"]
+source_file="res://art/models/cabin/Cabin_Colider.obj"
+dest_files=["res://.godot/imported/Cabin_Colider.obj-0ee3a0660d8f35f2f503363253ad10fa.mesh", "res://.godot/imported/Cabin_Colider.obj-0ee3a0660d8f35f2f503363253ad10fa.mesh"]
 
 [params]
 

--- a/faster-than-scrap/art/models/cabin/Cabin_Model.obj.import
+++ b/faster-than-scrap/art/models/cabin/Cabin_Model.obj.import
@@ -4,14 +4,14 @@ importer="wavefront_obj"
 importer_version=1
 type="Mesh"
 uid="uid://d3jn6wcbnxlbs"
-path="res://.godot/imported/Cabin_Model.obj-20b139ffafd787730869c8beca8cbfd0.mesh"
+path="res://.godot/imported/Cabin_Model.obj-b8c33384132d308518aeeb55f6e04bf4.mesh"
 
 [deps]
 
-files=["res://.godot/imported/Cabin_Model.obj-20b139ffafd787730869c8beca8cbfd0.mesh"]
+files=["res://.godot/imported/Cabin_Model.obj-b8c33384132d308518aeeb55f6e04bf4.mesh"]
 
-source_file="res://art/Models/cabin/Cabin_Model.obj"
-dest_files=["res://.godot/imported/Cabin_Model.obj-20b139ffafd787730869c8beca8cbfd0.mesh", "res://.godot/imported/Cabin_Model.obj-20b139ffafd787730869c8beca8cbfd0.mesh"]
+source_file="res://art/models/cabin/Cabin_Model.obj"
+dest_files=["res://.godot/imported/Cabin_Model.obj-b8c33384132d308518aeeb55f6e04bf4.mesh", "res://.godot/imported/Cabin_Model.obj-b8c33384132d308518aeeb55f6e04bf4.mesh"]
 
 [params]
 

--- a/faster-than-scrap/art/models/common_gun/common_gun.obj.import
+++ b/faster-than-scrap/art/models/common_gun/common_gun.obj.import
@@ -4,14 +4,14 @@ importer="wavefront_obj"
 importer_version=1
 type="Mesh"
 uid="uid://lwlx588xi1eg"
-path="res://.godot/imported/common_gun.obj-41cdc3bbf3fa54ea4e8caa715d8d9bc7.mesh"
+path="res://.godot/imported/common_gun.obj-e32eec6eec13ea9632e3e39bd792bb02.mesh"
 
 [deps]
 
-files=["res://.godot/imported/common_gun.obj-41cdc3bbf3fa54ea4e8caa715d8d9bc7.mesh"]
+files=["res://.godot/imported/common_gun.obj-e32eec6eec13ea9632e3e39bd792bb02.mesh"]
 
-source_file="res://art/Models/common_gun/common_gun.obj"
-dest_files=["res://.godot/imported/common_gun.obj-41cdc3bbf3fa54ea4e8caa715d8d9bc7.mesh", "res://.godot/imported/common_gun.obj-41cdc3bbf3fa54ea4e8caa715d8d9bc7.mesh"]
+source_file="res://art/models/common_gun/common_gun.obj"
+dest_files=["res://.godot/imported/common_gun.obj-e32eec6eec13ea9632e3e39bd792bb02.mesh", "res://.godot/imported/common_gun.obj-e32eec6eec13ea9632e3e39bd792bb02.mesh"]
 
 [params]
 

--- a/faster-than-scrap/art/models/common_gun/common_gun_collider.obj.import
+++ b/faster-than-scrap/art/models/common_gun/common_gun_collider.obj.import
@@ -4,14 +4,14 @@ importer="wavefront_obj"
 importer_version=1
 type="Mesh"
 uid="uid://b6j1772j0qoxg"
-path="res://.godot/imported/common_gun_collider.obj-f2503263e5d30f62b986173bca79c8d1.mesh"
+path="res://.godot/imported/common_gun_collider.obj-3c1e052226b48b91bf1d015f8858a4e5.mesh"
 
 [deps]
 
-files=["res://.godot/imported/common_gun_collider.obj-f2503263e5d30f62b986173bca79c8d1.mesh"]
+files=["res://.godot/imported/common_gun_collider.obj-3c1e052226b48b91bf1d015f8858a4e5.mesh"]
 
-source_file="res://art/Models/common_gun/common_gun_collider.obj"
-dest_files=["res://.godot/imported/common_gun_collider.obj-f2503263e5d30f62b986173bca79c8d1.mesh", "res://.godot/imported/common_gun_collider.obj-f2503263e5d30f62b986173bca79c8d1.mesh"]
+source_file="res://art/models/common_gun/common_gun_collider.obj"
+dest_files=["res://.godot/imported/common_gun_collider.obj-3c1e052226b48b91bf1d015f8858a4e5.mesh", "res://.godot/imported/common_gun_collider.obj-3c1e052226b48b91bf1d015f8858a4e5.mesh"]
 
 [params]
 

--- a/faster-than-scrap/art/models/frame/frame.obj.import
+++ b/faster-than-scrap/art/models/frame/frame.obj.import
@@ -4,14 +4,14 @@ importer="wavefront_obj"
 importer_version=1
 type="Mesh"
 uid="uid://dyggmpc21gmcw"
-path="res://.godot/imported/frame.obj-943f43395b3b4b3c7c8db28f4895fde0.mesh"
+path="res://.godot/imported/frame.obj-813440b5fa0197698cac77b3be721a4c.mesh"
 
 [deps]
 
-files=["res://.godot/imported/frame.obj-943f43395b3b4b3c7c8db28f4895fde0.mesh"]
+files=["res://.godot/imported/frame.obj-813440b5fa0197698cac77b3be721a4c.mesh"]
 
-source_file="res://art/Models/frame/frame.obj"
-dest_files=["res://.godot/imported/frame.obj-943f43395b3b4b3c7c8db28f4895fde0.mesh", "res://.godot/imported/frame.obj-943f43395b3b4b3c7c8db28f4895fde0.mesh"]
+source_file="res://art/models/frame/frame.obj"
+dest_files=["res://.godot/imported/frame.obj-813440b5fa0197698cac77b3be721a4c.mesh", "res://.godot/imported/frame.obj-813440b5fa0197698cac77b3be721a4c.mesh"]
 
 [params]
 

--- a/faster-than-scrap/art/models/frame1/frame1.obj.import
+++ b/faster-than-scrap/art/models/frame1/frame1.obj.import
@@ -4,14 +4,14 @@ importer="wavefront_obj"
 importer_version=1
 type="Mesh"
 uid="uid://ilin5br3b8v2"
-path="res://.godot/imported/frame1.obj-b022aafb3705d7e43e7e25b755952d9e.mesh"
+path="res://.godot/imported/frame1.obj-40e2893046243f519747dfaededd70aa.mesh"
 
 [deps]
 
-files=["res://.godot/imported/frame1.obj-b022aafb3705d7e43e7e25b755952d9e.mesh"]
+files=["res://.godot/imported/frame1.obj-40e2893046243f519747dfaededd70aa.mesh"]
 
-source_file="res://art/Models/frame1/frame1.obj"
-dest_files=["res://.godot/imported/frame1.obj-b022aafb3705d7e43e7e25b755952d9e.mesh", "res://.godot/imported/frame1.obj-b022aafb3705d7e43e7e25b755952d9e.mesh"]
+source_file="res://art/models/frame1/frame1.obj"
+dest_files=["res://.godot/imported/frame1.obj-40e2893046243f519747dfaededd70aa.mesh", "res://.godot/imported/frame1.obj-40e2893046243f519747dfaededd70aa.mesh"]
 
 [params]
 

--- a/faster-than-scrap/art/models/frame1/frame1Collider.obj.import
+++ b/faster-than-scrap/art/models/frame1/frame1Collider.obj.import
@@ -4,14 +4,14 @@ importer="wavefront_obj"
 importer_version=1
 type="Mesh"
 uid="uid://68w7nor1of7l"
-path="res://.godot/imported/frame1Collider.obj-2f4be3759a60a69a711ce5a2489918bc.mesh"
+path="res://.godot/imported/frame1Collider.obj-e5ea4433c0f62c08287deb304861826d.mesh"
 
 [deps]
 
-files=["res://.godot/imported/frame1Collider.obj-2f4be3759a60a69a711ce5a2489918bc.mesh"]
+files=["res://.godot/imported/frame1Collider.obj-e5ea4433c0f62c08287deb304861826d.mesh"]
 
-source_file="res://art/Models/frame1/frame1Collider.obj"
-dest_files=["res://.godot/imported/frame1Collider.obj-2f4be3759a60a69a711ce5a2489918bc.mesh", "res://.godot/imported/frame1Collider.obj-2f4be3759a60a69a711ce5a2489918bc.mesh"]
+source_file="res://art/models/frame1/frame1Collider.obj"
+dest_files=["res://.godot/imported/frame1Collider.obj-e5ea4433c0f62c08287deb304861826d.mesh", "res://.godot/imported/frame1Collider.obj-e5ea4433c0f62c08287deb304861826d.mesh"]
 
 [params]
 

--- a/faster-than-scrap/art/models/thruster/thruster.obj.import
+++ b/faster-than-scrap/art/models/thruster/thruster.obj.import
@@ -4,14 +4,14 @@ importer="wavefront_obj"
 importer_version=1
 type="Mesh"
 uid="uid://bfla2gv2cw50c"
-path="res://.godot/imported/thruster.obj-d086e2d68d69dcec490dc31e91cfd5cb.mesh"
+path="res://.godot/imported/thruster.obj-34ee02ae57537c74038c86b8f04a860e.mesh"
 
 [deps]
 
-files=["res://.godot/imported/thruster.obj-d086e2d68d69dcec490dc31e91cfd5cb.mesh"]
+files=["res://.godot/imported/thruster.obj-34ee02ae57537c74038c86b8f04a860e.mesh"]
 
-source_file="res://art/Models/thruster/thruster.obj"
-dest_files=["res://.godot/imported/thruster.obj-d086e2d68d69dcec490dc31e91cfd5cb.mesh", "res://.godot/imported/thruster.obj-d086e2d68d69dcec490dc31e91cfd5cb.mesh"]
+source_file="res://art/models/thruster/thruster.obj"
+dest_files=["res://.godot/imported/thruster.obj-34ee02ae57537c74038c86b8f04a860e.mesh", "res://.godot/imported/thruster.obj-34ee02ae57537c74038c86b8f04a860e.mesh"]
 
 [params]
 

--- a/faster-than-scrap/art/models/thruster/thruster_collider.obj.import
+++ b/faster-than-scrap/art/models/thruster/thruster_collider.obj.import
@@ -4,14 +4,14 @@ importer="wavefront_obj"
 importer_version=1
 type="Mesh"
 uid="uid://de18yreyuomu1"
-path="res://.godot/imported/thruster_collider.obj-7829c16bf7cac3a062ca032bc6ad89fa.mesh"
+path="res://.godot/imported/thruster_collider.obj-6fcce49277aec0a7614043135d3db9ca.mesh"
 
 [deps]
 
-files=["res://.godot/imported/thruster_collider.obj-7829c16bf7cac3a062ca032bc6ad89fa.mesh"]
+files=["res://.godot/imported/thruster_collider.obj-6fcce49277aec0a7614043135d3db9ca.mesh"]
 
-source_file="res://art/Models/thruster/thruster_collider.obj"
-dest_files=["res://.godot/imported/thruster_collider.obj-7829c16bf7cac3a062ca032bc6ad89fa.mesh", "res://.godot/imported/thruster_collider.obj-7829c16bf7cac3a062ca032bc6ad89fa.mesh"]
+source_file="res://art/models/thruster/thruster_collider.obj"
+dest_files=["res://.godot/imported/thruster_collider.obj-6fcce49277aec0a7614043135d3db9ca.mesh", "res://.godot/imported/thruster_collider.obj-6fcce49277aec0a7614043135d3db9ca.mesh"]
 
 [params]
 

--- a/faster-than-scrap/prefabs/VFX/shield_vfx.tscn
+++ b/faster-than-scrap/prefabs/VFX/shield_vfx.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=4 format=3 uid="uid://3a5vwad6lsnu"]
 
 [ext_resource type="Shader" uid="uid://ohokcopb2fdp" path="res://art/Shaders/Shield.tres" id="1_mu0sc"]
-[ext_resource type="ArrayMesh" uid="uid://cadsh5rgfnp6t" path="res://art/Models/Shield.obj" id="2_bgmlk"]
+[ext_resource type="ArrayMesh" uid="uid://cadsh5rgfnp6t" path="res://art/models/Shield.obj" id="2_bgmlk"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_bbfm5"]
 render_priority = 0

--- a/faster-than-scrap/scenes/build_ship.tscn
+++ b/faster-than-scrap/scenes/build_ship.tscn
@@ -8,8 +8,8 @@
 [ext_resource type="Script" path="res://code/ship/modules/module.gd" id="3_kgbhb"]
 [ext_resource type="Material" uid="uid://brspeokluwub5" path="res://art/materials/UI/ShipBuilder/outline_flash.tres" id="4_sra6p"]
 [ext_resource type="FontFile" uid="uid://c46lihhopk2wc" path="res://art/Fonts/PressStart2P-Regular.ttf" id="6_au3vu"]
-[ext_resource type="ArrayMesh" uid="uid://ilin5br3b8v2" path="res://art/Models/frame1/frame1.obj" id="8_2lyi2"]
-[ext_resource type="ArrayMesh" uid="uid://bfla2gv2cw50c" path="res://art/Models/thruster/thruster.obj" id="9_x0rib"]
+[ext_resource type="ArrayMesh" uid="uid://ilin5br3b8v2" path="res://art/models/frame1/frame1.obj" id="8_2lyi2"]
+[ext_resource type="ArrayMesh" uid="uid://bfla2gv2cw50c" path="res://art/models/thruster/thruster.obj" id="9_x0rib"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_x5wpm"]
 font = ExtResource("6_au3vu")


### PR DESCRIPTION
All models turned into prefabs, stored as scenes inside art/model_prefabs folder. Each prefab contains 3d node as a parent and a model itself with textures assigned. 

![image](https://github.com/user-attachments/assets/55d03667-08f6-465f-ada9-e7fb17952224)

Example of prefab node tree:
![image](https://github.com/user-attachments/assets/2d0609fb-9a3a-46bb-b702-f42c115d8dd1)

Any future models will also get a prefab added alongside with model itself (same branch)