### PR TITLE
Fix collision damage to new modules

### DIFF
--- a/faster-than-scrap/Sandbox/Mikulski/asteroids_test.tscn
+++ b/faster-than-scrap/Sandbox/Mikulski/asteroids_test.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=11 format=3 uid="uid://bkn8atkk3qg3d"]
+[gd_scene load_steps=10 format=3 uid="uid://bkn8atkk3qg3d"]
 
 [ext_resource type="PackedScene" uid="uid://dn3mypfoixbpt" path="res://prefabs/environment/asteroid.tscn" id="2_jtlwr"]
 [ext_resource type="PackedScene" uid="uid://b66go7dtdv2m1" path="res://prefabs/modules/module_base.tscn" id="2_jusb2"]
-[ext_resource type="PackedScene" uid="uid://hs3ujnysju5o" path="res://prefabs/collision_damage_calculator.tscn" id="3_rgp7d"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_6b47d"]
 
@@ -135,8 +134,12 @@ mesh = SubResource("BoxMesh_t8gxn")
 [node name="CollisionShape3D" type="CollisionShape3D" parent="border4"]
 shape = SubResource("BoxShape3D_uijbs")
 
-[node name="BaseModule" parent="." instance=ExtResource("2_jusb2")]
+[node name="RigidBody3D" type="RigidBody3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.30498, 2.38419e-07, 4.52976)
+gravity_scale = 0.0
 
-[node name="CollisionDamageCalculator" parent="BaseModule" node_paths=PackedStringArray("calculated_body") instance=ExtResource("3_rgp7d")]
-calculated_body = NodePath("..")
+[node name="BaseModule" parent="RigidBody3D" instance=ExtResource("2_jusb2")]
+
+[editable path="RigidBody3D/BaseModule"]
+[editable path="RigidBody3D/BaseModule/ModuleDisplay"]
+[editable path="RigidBody3D/BaseModule/DamageController2"]

--- a/faster-than-scrap/Sandbox/Mikulski/asteroids_test2.tscn
+++ b/faster-than-scrap/Sandbox/Mikulski/asteroids_test2.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=11 format=3 uid="uid://cvxigl75qswd"]
+[gd_scene load_steps=10 format=3 uid="uid://cvxigl75qswd"]
 
 [ext_resource type="PackedScene" uid="uid://dn3mypfoixbpt" path="res://prefabs/environment/asteroid.tscn" id="1_xn4ll"]
 [ext_resource type="PackedScene" uid="uid://b66go7dtdv2m1" path="res://prefabs/modules/module_base.tscn" id="2_2ulhf"]
-[ext_resource type="PackedScene" uid="uid://hs3ujnysju5o" path="res://prefabs/collision_damage_calculator.tscn" id="3_rp73k"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_6b47d"]
 
@@ -103,8 +102,12 @@ mesh = SubResource("BoxMesh_t8gxn")
 [node name="CollisionShape3D" type="CollisionShape3D" parent="border4"]
 shape = SubResource("BoxShape3D_uijbs")
 
-[node name="BaseModule" parent="." instance=ExtResource("2_2ulhf")]
+[node name="RigidBody3D" type="RigidBody3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.30498, 2.38419e-07, 4.52976)
+gravity_scale = 0.0
 
-[node name="CollisionDamageCalculator" parent="BaseModule" node_paths=PackedStringArray("calculated_body") instance=ExtResource("3_rp73k")]
-calculated_body = NodePath("..")
+[node name="BaseModule" parent="RigidBody3D" instance=ExtResource("2_2ulhf")]
+
+[editable path="RigidBody3D/BaseModule"]
+[editable path="RigidBody3D/BaseModule/ModuleDisplay"]
+[editable path="RigidBody3D/BaseModule/DamageController2"]

--- a/faster-than-scrap/Sandbox/Mikulski/asteroids_test3.tscn
+++ b/faster-than-scrap/Sandbox/Mikulski/asteroids_test3.tscn
@@ -1,13 +1,6 @@
-[gd_scene load_steps=7 format=3 uid="uid://blv3xvoqgc2lu"]
+[gd_scene load_steps=4 format=3 uid="uid://blv3xvoqgc2lu"]
 
 [ext_resource type="PackedScene" uid="uid://b66go7dtdv2m1" path="res://prefabs/modules/module_base.tscn" id="2_ta5ir"]
-[ext_resource type="PackedScene" uid="uid://hs3ujnysju5o" path="res://prefabs/collision_damage_calculator.tscn" id="3_il1ev"]
-
-[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_v4vkb"]
-bounce = 1.0
-
-[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_7rc8s"]
-bounce = 1.0
 
 [sub_resource type="SphereMesh" id="SphereMesh_8rabm"]
 
@@ -18,24 +11,6 @@ bounce = 1.0
 [node name="OmniLight3D" type="OmniLight3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 64.1306, 0)
 omni_range = 4096.0
-
-[node name="BaseModule" parent="." instance=ExtResource("2_ta5ir")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -8.00232)
-physics_material_override = SubResource("PhysicsMaterial_v4vkb")
-linear_velocity = Vector3(0, 0, 10)
-linear_damp_mode = 1
-
-[node name="CollisionDamageCalculator" parent="BaseModule" node_paths=PackedStringArray("calculated_body") instance=ExtResource("3_il1ev")]
-calculated_body = NodePath("..")
-
-[node name="BaseModule2" parent="." instance=ExtResource("2_ta5ir")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 4.53)
-physics_material_override = SubResource("PhysicsMaterial_7rc8s")
-linear_velocity = Vector3(0, 0, -10)
-linear_damp_mode = 1
-
-[node name="CollisionDamageCalculator" parent="BaseModule2" node_paths=PackedStringArray("calculated_body") instance=ExtResource("3_il1ev")]
-calculated_body = NodePath("..")
 
 [node name="Camera3D" type="Camera3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 0.0779893, 0.996954, 0, -0.996954, 0.0779893, 4.30498, 16.3629, 0.000386924)
@@ -61,3 +36,22 @@ skeleton = NodePath("")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D"]
 shape = SubResource("SphereShape3D_gdxup")
+
+[node name="RigidBody3D2" type="RigidBody3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.30498, 2.38419e-07, 4.52976)
+gravity_scale = 0.0
+
+[node name="BaseModule" parent="RigidBody3D2" instance=ExtResource("2_ta5ir")]
+
+[node name="RigidBody3D3" type="RigidBody3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.30498, 2.38419e-07, 4.52976)
+gravity_scale = 0.0
+
+[node name="BaseModule" parent="RigidBody3D3" instance=ExtResource("2_ta5ir")]
+
+[editable path="RigidBody3D2/BaseModule"]
+[editable path="RigidBody3D2/BaseModule/ModuleDisplay"]
+[editable path="RigidBody3D2/BaseModule/DamageController2"]
+[editable path="RigidBody3D3/BaseModule"]
+[editable path="RigidBody3D3/BaseModule/ModuleDisplay"]
+[editable path="RigidBody3D3/BaseModule/DamageController2"]

--- a/faster-than-scrap/Sandbox/Wierzba/flyable_ship/fly_fly.tscn
+++ b/faster-than-scrap/Sandbox/Wierzba/flyable_ship/fly_fly.tscn
@@ -44,7 +44,7 @@ script = ExtResource("3_p6uct")
 [node name="FlyableShip2" parent="." instance=ExtResource("3_uvdhe")]
 
 [node name="DamageArea3D_Stay" type="Area3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.78209, 0, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -7.50583, 0, 0)
 collision_layer = 2
 collision_mask = 2
 script = ExtResource("4_0oqmj")

--- a/faster-than-scrap/code/collision_damage_calculator.gd
+++ b/faster-than-scrap/code/collision_damage_calculator.gd
@@ -34,7 +34,7 @@ func _process(_delta: float) -> void:
 
 
 func _find_parent_collision(
-	body_rid: RID, body: Node, body_shape_index: int, local_shape_index: int
+	_body_rid: RID, body: Node, _body_shape_index: int, local_shape_index: int
 ) -> void:
 	if not include_other_shapes and calculated_body.get_child(local_shape_index) != shape:
 		return

--- a/faster-than-scrap/code/collision_damage_calculator.gd
+++ b/faster-than-scrap/code/collision_damage_calculator.gd
@@ -1,19 +1,29 @@
 extends Node
 
 @export_category("ColisionCalculator")
-@export var calculated_body: PhysicsBody3D
+## Target to which the damage will be dealt
+@export var damageable: Damageable
+## Primary shape that will be taken into account
+@export var shape: CollisionShape3D
+## If true, all shapes will be taken into account when
+## calculating damage
+@export var include_other_shapes: bool = false
+
 @export_group("ColisionModifiers")
 @export var flat_damage_reduction: float = 10.0
 @export var self_damage_multiplier: float = 1.0
 @export var dealt_damage_multiplier: float = 1.0
 
+## Object which will react to collisions
+var calculated_body: PhysicsBody3D
 var pre_collision_velosity: Vector3
 
 
 func _ready() -> void:
+	calculated_body = shape.get_parent_node_3d()
 	calculated_body.set_meta("collision_damage_calculator", self)
 
-	calculated_body.body_entered.connect(_find_parent_collision)
+	calculated_body.body_shape_entered.connect(_find_parent_collision)
 	calculated_body.contact_monitor = true
 	if calculated_body.max_contacts_reported <= 0:
 		calculated_body.max_contacts_reported = 10
@@ -23,12 +33,14 @@ func _process(_delta: float) -> void:
 	pre_collision_velosity = calculated_body.linear_velocity
 
 
-func _find_parent_collision(body: Node) -> void:
-	var damage: float = calculate_damage(calculated_body, body)
-	calculated_body.take_damage(damage)
+func _find_parent_collision(
+	body_rid: RID, body: Node, body_shape_index: int, local_shape_index: int
+) -> void:
+	var damage: Damage = calculate_damage(calculated_body, body)
+	damageable.take_damage(damage, body)
 
 
-func calculate_damage(me: Node, oponent: Node) -> float:
+func calculate_damage(me: Node, oponent: Node) -> Damage:
 	var oponet_calculator: Node
 	if oponent.has_meta("collision_damage_calculator"):
 		oponet_calculator = oponent.get_meta("collision_damage_calculator")
@@ -52,12 +64,12 @@ func calculate_damage(me: Node, oponent: Node) -> float:
 		self_dmg_mult *= oponet_calculator.dealt_damage_multiplier
 
 	# return result
-	var damage: float = base_damage * self_dmg_mult
+	var damage: Damage = Damage.new(base_damage * self_dmg_mult)
 	if "mass" in oponent:
-		damage *= oponent.mass / (me.mass + oponent.mass)
+		damage.value *= oponent.mass / (me.mass + oponent.mass)
 
-	damage -= flat_damage_reduction
-	if damage <= 0:
-		damage = 0
+	damage.value -= flat_damage_reduction
+	if damage.value <= 0:
+		damage.value = 0
 	print(damage)
 	return damage

--- a/faster-than-scrap/code/collision_damage_calculator.gd
+++ b/faster-than-scrap/code/collision_damage_calculator.gd
@@ -36,6 +36,8 @@ func _process(_delta: float) -> void:
 func _find_parent_collision(
 	body_rid: RID, body: Node, body_shape_index: int, local_shape_index: int
 ) -> void:
+	if not include_other_shapes and calculated_body.get_child(local_shape_index) != shape:
+		return
 	var damage: Damage = calculate_damage(calculated_body, body)
 	damageable.take_damage(damage, body)
 

--- a/faster-than-scrap/prefabs/environment/asteroid.tscn
+++ b/faster-than-scrap/prefabs/environment/asteroid.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=6 format=3 uid="uid://dn3mypfoixbpt"]
+[gd_scene load_steps=7 format=3 uid="uid://dn3mypfoixbpt"]
 
 [ext_resource type="Script" uid="uid://chekqae75l00d" path="res://code/evironment/asteroid.gd" id="1_dsopr"]
 [ext_resource type="PackedScene" uid="uid://hs3ujnysju5o" path="res://prefabs/collision_damage_calculator.tscn" id="2_wuo07"]
+[ext_resource type="PackedScene" uid="uid://0txf83d46q4j" path="res://prefabs/modules/functional_components/damage_controller.tscn" id="3_nu0y7"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_gro5k"]
 bounce = 1.0
@@ -26,5 +27,10 @@ shape = SubResource("SphereShape3D_keyhs")
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]
 mesh = SubResource("SphereMesh_ix2ef")
 
-[node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("calculated_body") instance=ExtResource("2_wuo07")]
-calculated_body = NodePath("..")
+[node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("2_wuo07")]
+damageable = NodePath("../DamageController/Damageable")
+shape = NodePath("../CollisionShape3D")
+
+[node name="DamageController" parent="." instance=ExtResource("3_nu0y7")]
+
+[editable path="DamageController"]

--- a/faster-than-scrap/prefabs/modules/cockpit.tscn
+++ b/faster-than-scrap/prefabs/modules/cockpit.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=6 format=3 uid="uid://dqaprpym1uev"]
+[gd_scene load_steps=7 format=3 uid="uid://dqaprpym1uev"]
 
 [ext_resource type="Script" uid="uid://csi36bbd5ji87" path="res://code/ship/modules/cockpit.gd" id="1_q5512"]
 [ext_resource type="Texture2D" uid="uid://dmggh2ftab7ht" path="res://art/textures/UI/Module Icons/Placeholder/Cockpit Icon.png" id="2_mk35a"]
 [ext_resource type="PackedScene" uid="uid://0txf83d46q4j" path="res://prefabs/modules/functional_components/damage_controller.tscn" id="3_ttrqs"]
+[ext_resource type="PackedScene" uid="uid://hs3ujnysju5o" path="res://prefabs/collision_damage_calculator.tscn" id="4_ux3ip"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_4r7dq"]
 
@@ -28,6 +29,10 @@ texture = ExtResource("2_mk35a")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="DamageController2/Damageable" index="0"]
 shape = SubResource("BoxShape3D_4r7dq")
+
+[node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("4_ux3ip")]
+damageable = NodePath("../DamageController2/Damageable")
+shape = NodePath("..")
 
 [connection signal="damaged" from="DamageController2" to="." method="take_damage"]
 

--- a/faster-than-scrap/prefabs/modules/module_base.tscn
+++ b/faster-than-scrap/prefabs/modules/module_base.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=7 format=3 uid="uid://b66go7dtdv2m1"]
+[gd_scene load_steps=8 format=3 uid="uid://b66go7dtdv2m1"]
 
 [ext_resource type="Script" uid="uid://cs6qd5cf3gviv" path="res://code/ship/modules/module.gd" id="1_if6ta"]
 [ext_resource type="PackedScene" uid="uid://b5ri43mxkksdw" path="res://prefabs/modules/functional_components/module_display.tscn" id="2_4crnk"]
 [ext_resource type="PackedScene" uid="uid://0txf83d46q4j" path="res://prefabs/modules/functional_components/damage_controller.tscn" id="4_bknuf"]
+[ext_resource type="PackedScene" uid="uid://hs3ujnysju5o" path="res://prefabs/collision_damage_calculator.tscn" id="4_s0cg4"]
 
 [sub_resource type="SphereShape3D" id="SphereShape3D_1whwh"]
 radius = 0.45
@@ -36,6 +37,10 @@ metadata/_edit_group_ = true
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="DamageController2/Damageable" index="0"]
 shape = SubResource("SphereShape3D_e1j53")
+
+[node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("4_s0cg4")]
+damageable = NodePath("../DamageController2/Damageable")
+shape = NodePath("..")
 
 [connection signal="damaged" from="DamageController2" to="." method="take_damage"]
 

--- a/faster-than-scrap/prefabs/modules/module_base.tscn
+++ b/faster-than-scrap/prefabs/modules/module_base.tscn
@@ -41,6 +41,7 @@ shape = SubResource("SphereShape3D_e1j53")
 [node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("4_s0cg4")]
 damageable = NodePath("../DamageController2/Damageable")
 shape = NodePath("..")
+self_damage_multiplier = 5.0
 
 [connection signal="damaged" from="DamageController2" to="." method="take_damage"]
 

--- a/faster-than-scrap/prefabs/modules/shield_module.tscn
+++ b/faster-than-scrap/prefabs/modules/shield_module.tscn
@@ -1,14 +1,15 @@
-[gd_scene load_steps=17 format=3 uid="uid://b6fx656pcno7s"]
+[gd_scene load_steps=18 format=3 uid="uid://b6fx656pcno7s"]
 
 [ext_resource type="Script" uid="uid://dsdbrxhbn35w7" path="res://code/ship/modules/shield_module.gd" id="1_qfqke"]
 [ext_resource type="Script" uid="uid://c47vgfakrvoxf" path="res://code/ship/modules/Shield.gd" id="2_yota5"]
-[ext_resource type="AudioStream" uid="uid://cfv8l5dmivhc5" path="res://art/audio/sounds/shield_applying_sound.wav" id="3_t2mx0"]
+[ext_resource type="AudioStream" uid="uid://c7e1p4aepud3d" path="res://art/audio/sounds/shield_applying_sound.wav" id="3_t2mx0"]
 [ext_resource type="AudioStream" uid="uid://bhtfb6630u1js" path="res://art/audio/sounds/shield_shattering_sound.wav" id="4_o2yw7"]
 [ext_resource type="AudioStream" uid="uid://bq3myi1evd56a" path="res://art/audio/sounds/shield_takingdmg_sound.wav" id="5_ul8cr"]
 [ext_resource type="PackedScene" uid="uid://3a5vwad6lsnu" path="res://prefabs/VFX/shield_vfx.tscn" id="6_gvryf"]
 [ext_resource type="Shader" uid="uid://ohokcopb2fdp" path="res://art/Shaders/Shield.tres" id="7_rwr3c"]
 [ext_resource type="PackedScene" uid="uid://0txf83d46q4j" path="res://prefabs/modules/functional_components/damage_controller.tscn" id="8_e18hx"]
 [ext_resource type="PackedScene" uid="uid://b5ri43mxkksdw" path="res://prefabs/modules/functional_components/module_display.tscn" id="9_sdq7t"]
+[ext_resource type="PackedScene" uid="uid://hs3ujnysju5o" path="res://prefabs/collision_damage_calculator.tscn" id="10_sdq7t"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_x6hs4"]
 
@@ -126,6 +127,8 @@ shield = NodePath("Shield2")
 collider = NodePath("Shield2/Shield_Collision/CollisionShape3D")
 sprite = NodePath("ModuleDisplay/Sprite3D")
 label = NodePath("ModuleDisplay/Label3D")
+healthy_color = Color(0, 1, 0, 1)
+dead_color = Color(1, 0, 0, 1)
 metadata/_custom_type_script = "uid://dsdbrxhbn35w7"
 
 [node name="Shield2" type="Node3D" parent="." node_paths=PackedStringArray("animator", "audio_player", "collider")]
@@ -167,6 +170,10 @@ disabled = true
 shape = SubResource("BoxShape3D_x6hs4")
 
 [node name="ModuleDisplay" parent="." instance=ExtResource("9_sdq7t")]
+
+[node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("10_sdq7t")]
+damageable = NodePath("../DamageController/Damageable")
+shape = NodePath("..")
 
 [connection signal="damaged" from="DamageController" to="." method="take_damage"]
 

--- a/faster-than-scrap/prefabs/modules/thruster.tscn
+++ b/faster-than-scrap/prefabs/modules/thruster.tscn
@@ -57,6 +57,7 @@ shape = SubResource("BoxShape3D_lwypn")
 [node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("6_24upk")]
 damageable = NodePath("../DamageController/Damageable")
 shape = NodePath("..")
+self_damage_multiplier = 10.0
 
 [connection signal="damaged" from="DamageController" to="." method="take_damage"]
 

--- a/faster-than-scrap/prefabs/modules/thruster.tscn
+++ b/faster-than-scrap/prefabs/modules/thruster.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=9 format=3 uid="uid://taxlqo87sp7s"]
+[gd_scene load_steps=10 format=3 uid="uid://taxlqo87sp7s"]
 
 [ext_resource type="Script" uid="uid://6f2yjn6wgcun" path="res://code/ship/modules/weapons/weapon_module.gd" id="1_18ma3"]
 [ext_resource type="Script" uid="uid://crmxerc164n6q" path="res://code/weapons/constant_fire_weapon.gd" id="2_5rd74"]
 [ext_resource type="PackedScene" uid="uid://whj7or7t81c0" path="res://prefabs/projectiles/test_projectile.tscn" id="3_ywc6w"]
 [ext_resource type="PackedScene" uid="uid://b5ri43mxkksdw" path="res://prefabs/modules/functional_components/module_display.tscn" id="4_putpi"]
 [ext_resource type="PackedScene" uid="uid://0txf83d46q4j" path="res://prefabs/modules/functional_components/damage_controller.tscn" id="5_24upk"]
+[ext_resource type="PackedScene" uid="uid://hs3ujnysju5o" path="res://prefabs/collision_damage_calculator.tscn" id="6_24upk"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_lwypn"]
 size = Vector3(1.05, 0.935, 1.835)
@@ -21,8 +22,9 @@ recoil_force = 5.0
 attach_points = [NodePath("AttachPoints/AttachPoint")]
 sprite = NodePath("ModuleDisplay/Sprite3D")
 label = NodePath("ModuleDisplay/Label3D")
+healthy_color = Color(0, 1, 0, 1)
+dead_color = Color(1, 0, 0, 1)
 prize = 2
-
 
 [node name="Mesh" type="Node3D" parent="."]
 
@@ -51,6 +53,10 @@ transform = Transform3D(-1, 0, 8.74228e-08, 0, 1, 0, -8.74228e-08, 0, -1, 0, 0, 
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="DamageController/Damageable" index="0"]
 shape = SubResource("BoxShape3D_lwypn")
+
+[node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("6_24upk")]
+damageable = NodePath("../DamageController/Damageable")
+shape = NodePath("..")
 
 [connection signal="damaged" from="DamageController" to="." method="take_damage"]
 


### PR DESCRIPTION
Added collision damage all modules.
Fixed so it would work with new modules and to make it compatible with other type of objects (damageble).

Can be tested in sandboxes:
- mikulski/asteroids_test
- Wierzba/flyable_ship/fly_fly (hit the cube to damage the thruster)