### PR TITLE
Fixed most warnings

### DIFF
--- a/faster-than-scrap/code/map_select/nodes/map_node.gd
+++ b/faster-than-scrap/code/map_select/nodes/map_node.gd
@@ -104,8 +104,6 @@ func draw_selected():
 	var local_start = get_rect().get_center() - get_rect().position
 	var radius = (get_rect().size.x / 2) * (3.0 / 4)
 
-	var delta_angle = PI / arc_count
-
 	draw_arc(local_start, radius, angle, 2 * PI + angle, 5, Color.GRAY, 8)
 
 

--- a/faster-than-scrap/code/ship/modules/module.gd
+++ b/faster-than-scrap/code/ship/modules/module.gd
@@ -26,7 +26,7 @@ var was_key_pressed: bool = false
 
 var module_rigidbody_prefab = preload("res://prefabs/modules/module_rigidbody.tscn")
 
-var activation_key_saved: Key = 0
+var activation_key_saved: Key = KEY_NONE
 
 
 func _ready() -> void:
@@ -88,7 +88,6 @@ func _on_destroy() -> void:
 	_explode()
 	for child in child_modules:
 		var rb: RigidBody3D = module_rigidbody_prefab.instantiate()
-		var root = get_tree().get_root()
 		get_tree().get_root().add_child(rb)  # attach to scene root
 		child.reparent(rb)
 		rb.linear_velocity = ship.linear_velocity
@@ -98,7 +97,7 @@ func _on_destroy() -> void:
 
 func deactivate() -> void:
 	activation_key_saved = activation_key
-	activation_key = 0
+	activation_key = KEY_NONE
 
 
 func activate() -> void:
@@ -131,17 +130,17 @@ func _on_key_change() -> void:
 		if text.length() <= 0:
 			return
 		if text.length() <= 3:
-			label.font_size = 160 / text.length()
+			label.font_size = int(160.0 / text.length())
 		else:
-			label.font_size = 160 / text.length() * 2
+			label.font_size = int(160.0 / text.length() * 2)
 
 
 func has_child_module() -> bool:
 	return child_modules.size() > 0
 
 
-func set_ship_reference(ship: Ship) -> void:
-	self.ship = ship
+func set_ship_reference(ship_ref: Ship) -> void:
+	ship = ship_ref
 
 
 ## Returns the node3D which is the center of the attach point.
@@ -164,9 +163,9 @@ func create_ghost() -> ModuleGhost:
 	ghost.global_position = global_position
 
 	# duplicate module
-	var duplicate: Node = self.duplicate()
-	ghost.add_child(duplicate)
-	duplicate.position = Vector3.ZERO
+	var duplicate_node: Node = self.duplicate()
+	ghost.add_child(duplicate_node)
+	duplicate_node.position = Vector3.ZERO
 	ghost.module_to_ignore = self
 
 	return ghost

--- a/faster-than-scrap/code/ship/modules/weapons/weapon_module.gd
+++ b/faster-than-scrap/code/ship/modules/weapons/weapon_module.gd
@@ -41,6 +41,6 @@ func _recoil(force_multiplier: float) -> void:
 	)
 
 
-func set_ship_reference(ship: Ship) -> void:
-	super(ship)
-	weapon.ship = ship
+func set_ship_reference(ship_ref: Ship) -> void:
+	super(ship_ref)
+	weapon.ship = ship_ref


### PR DESCRIPTION
Fixed warnings concerning things like unused local variables, using ints as enum values, narrowing int conversion, shadowing names by local variables