### PR TITLE
Battery module

### DIFF
--- a/faster-than-scrap/code/building_ship/ship_builder.gd
+++ b/faster-than-scrap/code/building_ship/ship_builder.gd
@@ -260,6 +260,7 @@ func _attach_module() -> void:
 	active_module.set_ship_reference(attach_target.ship)  # copy the reference to the ship
 	attach_target.child_modules.append(active_module)
 	active_module.parent_module = attach_target
+	active_module.attach()
 
 
 ## Function for setting up the module, when it is to be dettached
@@ -267,6 +268,7 @@ func _attach_module() -> void:
 ## It will add an area3D if needed to allow clicking the module, and set module
 ## parameters.
 func _dettach_module() -> void:
+	active_module.detach()
 	active_module.set_ship_reference(null)
 	if active_module.parent_module != null:
 		active_module.parent_module.child_modules.erase(active_module)

--- a/faster-than-scrap/code/player/player_ship.gd
+++ b/faster-than-scrap/code/player/player_ship.gd
@@ -5,9 +5,9 @@ extends Ship
 ## Extension of Ship class.
 ## Supposed to be used only by player.
 
-signal energy_change
-signal energy_max_change
-signal energy_warning
+signal energy_change(energy: float)
+signal energy_max_change(max_energy: float)
+signal energy_warning(energy: float)
 
 @export var cockpit: Cockpit
 
@@ -70,7 +70,7 @@ func _on_energy_change() -> void:
 ## Called whenever the max energy amount changes.
 func _on_energy_max_change() -> void:
 	super()
-	energy_max_change.emit(energy)
+	energy_max_change.emit(max_energy)
 
 
 func use_energy(amount: float) -> bool:

--- a/faster-than-scrap/code/player/player_ship.gd
+++ b/faster-than-scrap/code/player/player_ship.gd
@@ -67,6 +67,12 @@ func _on_energy_change() -> void:
 	energy_change.emit(energy)
 
 
+## Called whenever the max energy amount changes.
+func _on_energy_max_change() -> void:
+	super()
+	energy_max_change.emit(energy)
+
+
 func use_energy(amount: float) -> bool:
 	if energy < amount:
 		energy_warning.emit()

--- a/faster-than-scrap/code/player/resource_bar.gd
+++ b/faster-than-scrap/code/player/resource_bar.gd
@@ -58,9 +58,12 @@ var wait_timer: float = 0
 
 func _ready() -> void:
 	var player_ship = GameManager.player_ship
+	player_ship.energy_max_change.connect(_on_max_change)
 	player_ship.energy_change.connect(_change_value)
-	player_ship.energy_max_change.connect(_change_value)
 	player_ship.energy_warning.connect(_change_value)
+
+	_on_max_change(player_ship.max_energy)
+	_change_value(player_ship.energy)
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/faster-than-scrap/code/player/resource_bar.gd
+++ b/faster-than-scrap/code/player/resource_bar.gd
@@ -60,10 +60,13 @@ func _ready() -> void:
 	var player_ship = GameManager.player_ship
 	player_ship.energy_max_change.connect(_on_max_change)
 	player_ship.energy_change.connect(_change_value)
-	player_ship.energy_warning.connect(_change_value)
+	player_ship.energy_warning.connect(_on_warning)
 
-	_on_max_change(player_ship.max_energy)
-	_change_value(player_ship.energy)
+	if max_value != player_ship.max_energy:
+		_on_max_change(player_ship.max_energy)
+
+	if value_main != player_ship.energy:
+		_change_value(player_ship.energy)
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/faster-than-scrap/code/ship/modules/battery_module.gd
+++ b/faster-than-scrap/code/ship/modules/battery_module.gd
@@ -1,0 +1,20 @@
+class_name BatteryModule
+
+extends Module
+
+@export var energy: float = 25
+
+
+func _on_destroy() -> void:
+	ship.max_energy -= energy
+	super()
+
+
+func set_ship_reference(ship_ref: Ship) -> void:
+	if ship_ref != ship:
+		if ship != null:
+			ship.max_energy -= energy
+		if ship_ref != null:
+			ship_ref.max_energy += energy
+
+	super(ship_ref)

--- a/faster-than-scrap/code/ship/modules/battery_module.gd
+++ b/faster-than-scrap/code/ship/modules/battery_module.gd
@@ -5,16 +5,13 @@ extends Module
 @export var energy: float = 25
 
 
-func _on_destroy() -> void:
-	ship.max_energy -= energy
+func detach() -> void:
+	if ship != null:
+		ship.max_energy -= energy
 	super()
 
 
-func set_ship_reference(ship_ref: Ship) -> void:
-	if ship_ref != ship:
-		if ship != null:
-			ship.max_energy -= energy
-		if ship_ref != null:
-			ship_ref.max_energy += energy
-
-	super(ship_ref)
+func attach() -> void:
+	if ship != null:
+		ship.max_energy += energy
+	super()

--- a/faster-than-scrap/code/ship/modules/battery_module.gd
+++ b/faster-than-scrap/code/ship/modules/battery_module.gd
@@ -3,15 +3,18 @@ class_name BatteryModule
 extends Module
 
 @export var energy: float = 25
+@export var energy_regeneration: float = 5
 
 
 func detach() -> void:
 	if ship != null:
 		ship.max_energy -= energy
+		ship.restore -= energy_regeneration
 	super()
 
 
 func attach() -> void:
 	if ship != null:
 		ship.max_energy += energy
+		ship.restore += energy_regeneration
 	super()

--- a/faster-than-scrap/code/ship/modules/battery_module.gd.uid
+++ b/faster-than-scrap/code/ship/modules/battery_module.gd.uid
@@ -1,0 +1,1 @@
+uid://urjr40lajiyq

--- a/faster-than-scrap/code/ship/modules/module.gd
+++ b/faster-than-scrap/code/ship/modules/module.gd
@@ -110,8 +110,19 @@ func _on_destroy() -> void:
 		child.reparent(rb)
 		rb.linear_velocity = ship.linear_velocity
 		child.deactivate()
+		child.detach()
+
+	detach()
 	queue_free()  # delete self as an object
 	destroyed.emit()
+
+
+func attach() -> void:
+	pass
+
+
+func detach() -> void:
+	pass
 
 
 func deactivate() -> void:

--- a/faster-than-scrap/code/ship/ship.gd
+++ b/faster-than-scrap/code/ship/ship.gd
@@ -7,7 +7,15 @@ signal damaged(hp_percent)
 ## Base class for player and enemy
 
 @export var energy: float = 100
-@export var max_energy: float = 100
+@export var max_energy: float = 100:
+	get:
+		return max_energy
+	set(value):
+		max_energy = value
+		_on_energy_max_change()
+		if energy > max_energy:
+			energy = max_energy
+			_on_energy_change()
 @export var restore: float = 10
 
 @export var max_hp: float = 10
@@ -29,6 +37,7 @@ func _ready() -> void:
 
 func _process(delta: float) -> void:
 	energy += restore * delta
+	_on_energy_change()
 	if energy > max_energy:
 		energy = max_energy
 
@@ -49,9 +58,14 @@ func _on_energy_change() -> void:
 	pass
 
 
+## Called whenever the max energy amount changes.
+func _on_energy_max_change() -> void:
+	pass
+
+
 func _on_take_damage(damage: Damage) -> void:
 	hp -= damage.value
-	damaged.emit(hp/max_hp)
+	damaged.emit(hp / max_hp)
 	if hp <= 0:
 		on_destroy()
 

--- a/faster-than-scrap/code/ship/ship.gd
+++ b/faster-than-scrap/code/ship/ship.gd
@@ -1,12 +1,22 @@
 class_name Ship
 extends Node3D
 
-signal destroyed(ship)
-signal damaged(hp_percent)
+signal destroyed(ship: Ship)
+signal damaged(hp_percent: float)
 
 ## Base class for player and enemy
 
-@export var energy: float = 100
+@export var energy: float = 100:
+	get:
+		return energy
+	set(value):
+		var start_energy = energy
+		energy = value
+		if energy > max_energy:
+			energy = max_energy
+		if energy != start_energy:
+			_on_energy_change()
+
 @export var max_energy: float = 100:
 	get:
 		return max_energy
@@ -15,7 +25,7 @@ signal damaged(hp_percent)
 		_on_energy_max_change()
 		if energy > max_energy:
 			energy = max_energy
-			_on_energy_change()
+
 @export var restore: float = 10
 
 @export var max_hp: float = 10
@@ -37,9 +47,6 @@ func _ready() -> void:
 
 func _process(delta: float) -> void:
 	energy += restore * delta
-	_on_energy_change()
-	if energy > max_energy:
-		energy = max_energy
 
 
 ## Called when module wants to use the ship's energy [member Ship.energy].
@@ -49,7 +56,6 @@ func use_energy(amount: float) -> bool:
 	if energy < amount:
 		return false
 	energy -= amount
-	_on_energy_change()
 	return true
 
 

--- a/faster-than-scrap/code/singletons/game_manager.gd
+++ b/faster-than-scrap/code/singletons/game_manager.gd
@@ -4,7 +4,7 @@ extends Node
 ## It is not supposed to be added to the scene tree!
 ## It is autoloaded and always available to be called from everywhere!
 
-signal new_game_state
+signal new_game_state(new_state: GameState.State)
 
 @export var game_state: GameState.State = GameState.State.MAIN_MENU
 @export var death_screen: PackedScene

--- a/faster-than-scrap/prefabs/modules/battery.tscn
+++ b/faster-than-scrap/prefabs/modules/battery.tscn
@@ -1,0 +1,72 @@
+[gd_scene load_steps=14 format=3 uid="uid://b8v177mewyt5j"]
+
+[ext_resource type="Script" uid="uid://urjr40lajiyq" path="res://code/ship/modules/battery_module.gd" id="1_aagdk"]
+[ext_resource type="Texture2D" uid="uid://cebxmyyc7xq5m" path="res://art/textures/frame/frame_Albedo.png" id="2_aagdk"]
+[ext_resource type="Texture2D" uid="uid://r30h1nnmjryd" path="res://art/textures/frame/frame_AO.png" id="3_0nt81"]
+[ext_resource type="ArrayMesh" uid="uid://dyggmpc21gmcw" path="res://art/models/modules/frame/frame.obj" id="3_6dylh"]
+[ext_resource type="PackedScene" uid="uid://b5ri43mxkksdw" path="res://prefabs/modules/functional_components/module_display.tscn" id="3_vdvrw"]
+[ext_resource type="PackedScene" uid="uid://0txf83d46q4j" path="res://prefabs/modules/functional_components/damage_controller.tscn" id="4_6dylh"]
+[ext_resource type="Texture2D" uid="uid://p1p3m7hu4bp2" path="res://art/textures/frame/frame_Metalness.png" id="4_7p43c"]
+[ext_resource type="PackedScene" uid="uid://hs3ujnysju5o" path="res://prefabs/collision_damage_calculator.tscn" id="5_mgd80"]
+[ext_resource type="Texture2D" uid="uid://cjv8e2sijiql6" path="res://art/textures/frame/frame_Normal.png" id="5_nemdb"]
+[ext_resource type="Texture2D" uid="uid://bqpvtwe8hkr0w" path="res://art/textures/frame/frame_Roughness.png" id="6_5g11m"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_jnq3k"]
+size = Vector3(1, 1, 1.075)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_ttear"]
+albedo_color = Color(0, 1, 0, 1)
+albedo_texture = ExtResource("2_aagdk")
+metallic = 1.0
+metallic_texture = ExtResource("4_7p43c")
+roughness_texture = ExtResource("6_5g11m")
+emission_enabled = true
+emission = Color(0, 0.490196, 0, 1)
+normal_enabled = true
+normal_texture = ExtResource("5_nemdb")
+ao_enabled = true
+ao_texture = ExtResource("3_0nt81")
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_e1j53"]
+
+[node name="Battery" type="CollisionShape3D" node_paths=PackedStringArray("attach_points", "sprite", "label")]
+shape = SubResource("BoxShape3D_jnq3k")
+script = ExtResource("1_aagdk")
+is_activable = false
+attach_points = [NodePath("AttachPoints/AttachPoint1")]
+sprite = NodePath("ModuleDisplay/Sprite3D")
+label = NodePath("ModuleDisplay/Label3D")
+healthy_color = Color(0, 1, 0, 1)
+dead_color = Color(1, 0, 0, 1)
+module_name = "Battery"
+description = "Increases ship max energy."
+
+[node name="Frame0Model" type="Node3D" parent="."]
+transform = Transform3D(0.645, 0, 0, 0, 0.645, 0, 0, 0, 0.645, 0, 0, 0)
+
+[node name="Frame0" type="MeshInstance3D" parent="Frame0Model"]
+material_override = SubResource("StandardMaterial3D_ttear")
+mesh = ExtResource("3_6dylh")
+
+[node name="AttachPoints" type="Node3D" parent="."]
+
+[node name="AttachPoint1" type="Node3D" parent="AttachPoints"]
+transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 5.85682e-09, 0, 0.566994)
+metadata/_edit_group_ = true
+
+[node name="ModuleDisplay" parent="." instance=ExtResource("3_vdvrw")]
+
+[node name="DamageController2" parent="." instance=ExtResource("4_6dylh")]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="DamageController2/Damageable" index="0"]
+shape = SubResource("SphereShape3D_e1j53")
+
+[node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("5_mgd80")]
+damageable = NodePath("../DamageController2/Damageable")
+shape = NodePath("..")
+self_damage_multiplier = 5.0
+
+[connection signal="damaged" from="DamageController2" to="." method="take_damage"]
+
+[editable path="ModuleDisplay"]
+[editable path="DamageController2"]

--- a/faster-than-scrap/prefabs/modules/shield_module.tscn
+++ b/faster-than-scrap/prefabs/modules/shield_module.tscn
@@ -126,6 +126,8 @@ points = PackedVector3Array(-0.951058, -0.000195742, -0.011405, 0.850515, -0.525
 [node name="ShieldModule" type="CollisionShape3D" node_paths=PackedStringArray("shield", "collider", "attach_points", "sprite", "label")]
 shape = SubResource("BoxShape3D_x6hs4")
 script = ExtResource("1_qfqke")
+energy_per_turning = 15.0
+energy_per_sec = 15.0
 shield = NodePath("Shield2")
 collider = NodePath("Shield2/Shield_Collision/CollisionShape3D")
 attach_points = [NodePath("AttachPoints/AttachPoint1")]

--- a/faster-than-scrap/prefabs/modules/thruster.tscn
+++ b/faster-than-scrap/prefabs/modules/thruster.tscn
@@ -46,6 +46,7 @@ Vector2i(1, 2): {
 shape = SubResource("BoxShape3D_lwypn")
 script = ExtResource("1_18ma3")
 weapon = NodePath("ConstantFireWeapon")
+allow_auto_fire = true
 attach_points = [NodePath("AttachPoints/AttachPoint")]
 sprite = NodePath("ModuleDisplay/Sprite3D")
 label = NodePath("ModuleDisplay/Label3D")
@@ -58,6 +59,7 @@ description = "Basic movement module. Activate to push ship forward (relative to
 [node name="ConstantFireWeapon" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -1.26313)
 script = ExtResource("2_5rd74")
+energy_cost = 10.0
 recoil_force = 300.0
 projectile = ExtResource("3_24upk")
 

--- a/faster-than-scrap/prefabs/modules/weapons/beam_module.tscn
+++ b/faster-than-scrap/prefabs/modules/weapons/beam_module.tscn
@@ -71,6 +71,7 @@ description = "One of basic weapons. Hold activation to shoot continous beam."
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.610518)
 script = ExtResource("2_7ulne")
 muzzle_flash = NodePath("Laser_Muzzle")
+energy_cost = 20.0
 recoil_force = 50.0
 projectile = ExtResource("3_nosfs")
 metadata/_custom_type_script = "uid://crmxerc164n6q"

--- a/faster-than-scrap/prefabs/modules/weapons/laser_module.tscn
+++ b/faster-than-scrap/prefabs/modules/weapons/laser_module.tscn
@@ -43,6 +43,7 @@ description = "One of basic weapons. Activate to shoot long-range projectile."
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.694184)
 script = ExtResource("2_nlg4d")
 muzzle_flash = NodePath("MuzzleFlash")
+energy_cost = 10.0
 cooldown = 0.5
 recoil_force = 50.0
 projectile = ExtResource("3_nlg4d")

--- a/faster-than-scrap/prefabs/modules/weapons/missile_module.tscn
+++ b/faster-than-scrap/prefabs/modules/weapons/missile_module.tscn
@@ -86,6 +86,7 @@ description = "Advanced waepon. Activate to release a slow-moving homing missile
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.610518)
 script = ExtResource("2_wf0w0")
 muzzle_flash = NodePath("MuzzleFlash")
+energy_cost = 25.0
 cooldown = 1.0
 recoil_force = 75.0
 projectile = ExtResource("3_duybm")

--- a/faster-than-scrap/scenes/build_ship.tscn
+++ b/faster-than-scrap/scenes/build_ship.tscn
@@ -311,7 +311,7 @@ metadata/_custom_type_script = "uid://16i5n2yxnlsr"
 [node name="Shop" type="Node3D" parent="." node_paths=PackedStringArray("bank_display", "deny_finish", "confirm_finish", "selected_module_display", "selected_module_description")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 21.2428, 0, 0)
 script = ExtResource("11_jtm63")
-modules = Array[String](["uid://cujiw86wtjlp8", "uid://cujiw86wtjlp8", "uid://cujiw86wtjlp8", "uid://gngfqbur01ep", "uid://gngfqbur01ep", "uid://dbajfkkhivhl0", "uid://dbajfkkhivhl0", "uid://cqkj1jovh07cf", "uid://cqkj1jovh07cf", "uid://taxlqo87sp7s", "uid://15te4x6fjtx4"])
+modules = Array[String](["uid://cujiw86wtjlp8", "uid://cujiw86wtjlp8", "uid://cujiw86wtjlp8", "uid://gngfqbur01ep", "uid://gngfqbur01ep", "uid://dbajfkkhivhl0", "uid://dbajfkkhivhl0", "uid://cqkj1jovh07cf", "uid://cqkj1jovh07cf", "uid://taxlqo87sp7s", "uid://15te4x6fjtx4", "uid://b8v177mewyt5j"])
 starting_bank = 3
 size_x = 8.323
 size_z = 12.573


### PR DESCRIPTION
Resolves #358 
The battery increases maximum energy of the ship when it is attached, and decreases it back, when it is detached.

-----

If you attach the battery in the shop, exit the shop, enter the shop, detach the battery and exit the shop, the UI breaks - the battery overlay is displayed to the right from where it should be. I *really* tried to fix this, but I have no idea how. The energy UI was made ages ago, so I'd consider this bug as another task tbh.

From the solutions I tried so far, I can see that in the shop (except the first shop, when starting the game) there are actually *two* HUDs, one of which is in the detached fly_ship scene. I tried just removing the HUD in the shop, as in reality it's not that useful for anything (the minimap is always empty anyways, and the ship preview is not super necessary), but for some reason the ship builder requires HUD for its raycast camera. Manually adding another camera is also not an option, as only the HUD camera can be zoomed in and out. I have no idea how to untangle this spaghetti without tearing everythin apart and building it from the ground up, so I will leave this bug as is for now.

-----

After adding energy cost to modules, I noticed that it is also incorrectly displayed in the energy HUD.