### PR TITLE
Create new hud on load

### DIFF
--- a/faster-than-scrap/code/evironment/hud_spawner.gd
+++ b/faster-than-scrap/code/evironment/hud_spawner.gd
@@ -2,8 +2,25 @@ class_name HudSpawner
 
 extends Node
 
+static var spawn_hud = false
+
+var hud_scene = load("res://prefabs/ui/hud.tscn")
+var hud: Hud
+
 
 func _ready() -> void:
-	var hud_scene = load("res://prefabs/ui/hud.tscn")
-	var hud = hud_scene.instantiate()
+	if spawn_hud:
+		_spawn()
+
+
+func _process(_delta: float) -> void:
+	if spawn_hud:
+		_spawn()
+
+
+func _spawn() -> void:
+	if hud != null:
+		hud.queue_free()
+	hud = hud_scene.instantiate()
 	add_child(hud)
+	spawn_hud = false

--- a/faster-than-scrap/code/scene_loader.gd
+++ b/faster-than-scrap/code/scene_loader.gd
@@ -106,6 +106,8 @@ func _attach_ship_with_hud(pos: Vector3 = Vector3.ZERO, rot: Vector3 = Vector3.Z
 	GameManager.player_ship.position = pos
 	GameManager.player_ship.rotation = rot
 
+	HudSpawner.spawn_hud = true
+
 
 ## attach the ship to the scene tree
 func _attach_ship_without_hud():

--- a/faster-than-scrap/scenes/levels/level_staples.tscn
+++ b/faster-than-scrap/scenes/levels/level_staples.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://b670jj7lnajsd" path="res://prefabs/environment/space_environment.tscn" id="3_40ga3"]
 [ext_resource type="Script" uid="uid://16i5n2yxnlsr" path="res://code/scene_loader.gd" id="4_ynct0"]
 [ext_resource type="PackedScene" uid="uid://b8vq1jqmowcwf" path="res://prefabs/pause_menu.tscn" id="5_w06h8"]
-[ext_resource type="Script" path="res://code/evironment/generate_nebulas.gd" id="6_dq8h5"]
+[ext_resource type="Script" uid="uid://f6d84uyul237" path="res://code/evironment/generate_nebulas.gd" id="6_dq8h5"]
 
 [node name="LevelBase" type="Node3D"]
 
@@ -38,3 +38,5 @@ autowrap_mode = 3
 
 [node name="Background" type="Node3D" parent="."]
 script = ExtResource("6_dq8h5")
+
+[connection signal="pressed" from="Button" to="SceneLoader" method="load_build_ship_scene"]


### PR DESCRIPTION
Fixes issue which aroused in #407 
Now hud is respawned each time fly ship scene is loaded.
Also minor fix to dev build ship button.
On main you can break the hud doing these steps:
- in shop add battery module
- leave
- enter shop, and detach batery
- see error
/\ This error is removed with this pr /\