### PR TITLE
Fixed projectiles hitting the ship when moving

### DIFF
--- a/faster-than-scrap/code/damage/damage_area_3d.gd
+++ b/faster-than-scrap/code/damage/damage_area_3d.gd
@@ -29,10 +29,18 @@ enum DamageType {
 ## If set to true, this node will be destroyed immediately after applying damage.
 @export var _die_on_hit: bool = false
 
+## The collision will start monitoring after waiting this number of seconds
+@export var collision_activation_delay: float = 0
+
 var _colliding_areas: Array[Damageable] = []
 
 
 func _ready():
+	if collision_activation_delay > 0:
+		monitoring = false
+		get_tree().create_timer(collision_activation_delay).timeout.connect(
+			func(): monitoring = true
+		)
 	area_entered.connect(_on_area_entered)
 	area_exited.connect(_on_area_exited)
 

--- a/faster-than-scrap/code/ship/ship.gd
+++ b/faster-than-scrap/code/ship/ship.gd
@@ -1,5 +1,5 @@
 class_name Ship
-extends Node3D
+extends RigidBody3D
 
 signal destroyed(ship: Ship)
 signal damaged(hp_percent: float)

--- a/faster-than-scrap/code/weapons/projectiles/projectile.gd
+++ b/faster-than-scrap/code/weapons/projectiles/projectile.gd
@@ -25,6 +25,10 @@ extends Node3D
 @export var particle_holder: WaitFree
 @export var particles: Array[GPUParticles3D]
 
+## Additional velocity applied to the projectile in every frame.
+## Used for applying the ship's speed to projectile after spawning.
+var velocity_offset: Vector3 = Vector3.ZERO
+
 var _current_lifetime: float = 0
 
 @onready var _damage_area: DamageArea3D = $DamageArea3D
@@ -45,6 +49,7 @@ func _process(delta: float) -> void:
 
 
 func _process_movement(delta: float) -> void:
+	global_position += velocity_offset * delta
 	var speed = velocity.sample_baked(_current_lifetime / lifetime)
 	speed *= velocity_multiplier
 	translate_object_local(Vector3.FORWARD * speed * delta)

--- a/faster-than-scrap/code/weapons/projectiles/projectile.gd
+++ b/faster-than-scrap/code/weapons/projectiles/projectile.gd
@@ -21,9 +21,6 @@ extends Node3D
 ## Note: In both cases, die_on_hit in the child [DamageArea3D] should be set to false.
 @export var die_on_hit: bool = true
 
-## The projectile's collisions will be activated after waiting this number of seconds
-@export var collision_activation_delay: float = 0.075
-
 ## Projectiles don't dissappear immidietly
 @export var particle_holder: WaitFree
 @export var particles: Array[GPUParticles3D]
@@ -38,12 +35,6 @@ var _current_lifetime: float = 0
 
 
 func _ready() -> void:
-	if collision_activation_delay > 0:
-		_damage_area.monitoring = false
-		get_tree().create_timer(collision_activation_delay).timeout.connect(
-			func(): _damage_area.monitoring = true
-		)
-
 	_damage_area.damage_applied.connect(_on_damage_applied)
 	for part in particles:
 		part.emitting = true

--- a/faster-than-scrap/code/weapons/projectiles/projectile.gd
+++ b/faster-than-scrap/code/weapons/projectiles/projectile.gd
@@ -21,6 +21,9 @@ extends Node3D
 ## Note: In both cases, die_on_hit in the child [DamageArea3D] should be set to false.
 @export var die_on_hit: bool = true
 
+## The projectile's collisions will be activated after waiting this number of seconds
+@export var collision_activation_delay: float = 0.075
+
 ## Projectiles don't dissappear immidietly
 @export var particle_holder: WaitFree
 @export var particles: Array[GPUParticles3D]
@@ -35,6 +38,12 @@ var _current_lifetime: float = 0
 
 
 func _ready() -> void:
+	if collision_activation_delay > 0:
+		_damage_area.monitoring = false
+		get_tree().create_timer(collision_activation_delay).timeout.connect(
+			func(): _damage_area.monitoring = true
+		)
+
 	_damage_area.damage_applied.connect(_on_damage_applied)
 	for part in particles:
 		part.emitting = true

--- a/faster-than-scrap/code/weapons/spawner_weapon.gd
+++ b/faster-than-scrap/code/weapons/spawner_weapon.gd
@@ -3,6 +3,7 @@ class_name SpawnerWeapon
 extends BaseWeapon
 @export var muzzle_flash: GPUParticles3D
 @export var warning: bool
+@export var apply_ship_velocity_to_projectiles: bool = true
 
 ## Weapon that can spawn multiple projectiles, such as bullets, laser bolts, etc.
 
@@ -16,6 +17,9 @@ func try_activate() -> Node3D:
 	recoil.emit(recoil_force)
 
 	var new_projectile = _spawn_projectile()
+
+	if apply_ship_velocity_to_projectiles and (new_projectile as Projectile != null):
+		new_projectile.velocity_offset = ship.linear_velocity
 
 	if !warning:
 		new_projectile.transform = global_transform

--- a/faster-than-scrap/prefabs/projectiles/basic_gun_projectile.tscn
+++ b/faster-than-scrap/prefabs/projectiles/basic_gun_projectile.tscn
@@ -84,6 +84,7 @@ script = ExtResource("2_bntxj")
 _damage_type = 0
 _damage = SubResource("Resource_x6y5o")
 _die_on_hit = true
+collision_activation_delay = 0.075
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="DamageArea3D"]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, -0.5)

--- a/faster-than-scrap/prefabs/projectiles/homing_missile.tscn
+++ b/faster-than-scrap/prefabs/projectiles/homing_missile.tscn
@@ -361,6 +361,7 @@ script = ExtResource("2_xnu3b")
 _damage_type = 0
 _damage = SubResource("Resource_43gyh")
 _die_on_hit = true
+collision_activation_delay = 0.075
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="DamageArea3D"]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -6.07488e-09, -0.611023)


### PR DESCRIPTION
Projectiles can now inherit the ship's velocity when being spawned, instead of always being spawned with their base velocity.

It's now also possible to set a delay, to prevent projectiles colliding short time after being spawned.
(The delay is necessary, because Godot processes collisions in a weird order, and the projectile first hits the ship after being spawned, before moving out of the way in the following frames)