### PR TITLE
Fixed infinite energy when repeatedly attaching and detaching battery

### DIFF
--- a/faster-than-scrap/code/ship/modules/battery_module.gd
+++ b/faster-than-scrap/code/ship/modules/battery_module.gd
@@ -5,6 +5,13 @@ extends Module
 @export var energy: float = 25
 @export var energy_regeneration: float = 5
 
+var _previous_ship_reference: Ship = null
+
+
+func set_ship_reference(ship_ref: Ship) -> void:
+	_previous_ship_reference = ship
+	super(ship_ref)
+
 
 func detach() -> void:
 	if ship != null:
@@ -14,7 +21,7 @@ func detach() -> void:
 
 
 func attach() -> void:
-	if ship != null:
+	if ship != null and ship != _previous_ship_reference:
 		ship.max_energy += energy
 		ship.restore += energy_regeneration
 	super()


### PR DESCRIPTION
Previously, if you clicked an attached battery in the ship editor and attached it back to the ship (instead of detaching it or moving it to the shop/inventory), the battery would add additional energy and regeneration to the ship. This PR fixes this issue.