### PR TITLE
Rounding up (instead of down) displayed energy value

### DIFF
--- a/faster-than-scrap/code/player/resource_bar.gd
+++ b/faster-than-scrap/code/player/resource_bar.gd
@@ -88,7 +88,7 @@ func _change_value(input: float) -> void:
 	value_main = input
 	bar_main.value = value_main
 
-	var temp: int = int(value_main)
+	var temp: int = ceili(value_main)
 	numbers.text = String.num_int64(temp)
 
 	if value_main > value_under:


### PR DESCRIPTION
Previously, when using only a single thruster with energy cost = 10 and ship's energy regeneration = 10, the energy was displayed as 99 instead of 100. This PR fixes this issue.