### PR TITLE
Roerder UI elements

### DIFF
--- a/faster-than-scrap/scenes/levels/level_staples.tscn
+++ b/faster-than-scrap/scenes/levels/level_staples.tscn
@@ -4,11 +4,13 @@
 [ext_resource type="PackedScene" uid="uid://b670jj7lnajsd" path="res://prefabs/environment/space_environment.tscn" id="3_40ga3"]
 [ext_resource type="Script" uid="uid://16i5n2yxnlsr" path="res://code/scene_loader.gd" id="4_ynct0"]
 [ext_resource type="PackedScene" uid="uid://b8vq1jqmowcwf" path="res://prefabs/pause_menu.tscn" id="5_w06h8"]
-[ext_resource type="Script" uid="uid://f6d84uyul237" path="res://code/evironment/generate_nebulas.gd" id="6_dq8h5"]
-[ext_resource type="PackedScene" uid="uid://bv13odmw2deac" path="res://prefabs/ui/vortex_warning.tscn" id="6_fj3oh"]
+[ext_resource type="Script" path="res://code/evironment/generate_nebulas.gd" id="6_dq8h5"]
+[ext_resource type="PackedScene" uid="uid://cdqva3petapu5" path="res://prefabs/ui/vortex_warning.tscn" id="6_fj3oh"]
 [ext_resource type="PackedScene" uid="uid://55masxr1fg7f" path="res://prefabs/vfx/particles/dust_particles.tscn" id="7_r20ym"]
 
 [node name="LevelStaples" type="Node3D"]
+
+[node name="VortexWarning" parent="." instance=ExtResource("6_fj3oh")]
 
 [node name="HudSpawner" type="Node" parent="."]
 script = ExtResource("2_g7p6o")
@@ -35,8 +37,6 @@ autowrap_mode = 3
 
 [node name="Background" type="Node3D" parent="."]
 script = ExtResource("6_dq8h5")
-
-[node name="VortexWarning" parent="." instance=ExtResource("6_fj3oh")]
 
 [node name="Dust Particles2" parent="." instance=ExtResource("7_r20ym")]
 


### PR DESCRIPTION
Vortex warning is now at the bottom of the UI elements order.
So the main menu and dev button (to shop) is now clickable.

To test just finish tutorial map (or move the shop_miniature close enough), leave the shop, and then try intercting with pause menu and dev button
