### PR TITLE
Change material "local to scene"

### DIFF
--- a/faster-than-scrap/prefabs/modules/shield_module.tscn
+++ b/faster-than-scrap/prefabs/modules/shield_module.tscn
@@ -19,6 +19,7 @@
 size = Vector3(0.78, 1, 1.085)
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_qjp2t"]
+resource_local_to_scene = true
 render_priority = 0
 shader = ExtResource("7_rwr3c")
 shader_parameter/anim_hit = 1.0


### PR DESCRIPTION
Shield now no longer remains open with new ship.
The issue is with the material. All shield had common material, but each should have it's own isntance. 
Checking the box "local to scene" fixes this.

To test just modify the modules_list to have only shield. Run the game, get into the shop, attach multiple shield, turn some on, get to main menu and repeat