### PR TITLE
Add a debug menu

### DIFF
--- a/faster-than-scrap/code/building_ship/ship_builder.gd
+++ b/faster-than-scrap/code/building_ship/ship_builder.gd
@@ -338,7 +338,7 @@ func _input(event: InputEvent):
 			## check if keyboard pressed
 			if event is InputEventKey and event.pressed:
 				var key_event: InputEventKey = event
-				if not key_event.keycode in active_module.NOT_ACTIVABLE_KEYS:
+				if not key_event.keycode in active_module.reserved_keys:
 					active_module.change_key(key_event.keycode)
 					state = State.NONE
 					choose_key_message.visible = false

--- a/faster-than-scrap/code/building_ship/shop.gd
+++ b/faster-than-scrap/code/building_ship/shop.gd
@@ -157,7 +157,7 @@ func _on_bank_change() -> void:
 
 
 func _on_finish_pressed() -> void:
-	if OS.is_debug_build() and not DebugMenu.money_checks:
+	if OS.is_debug_build() and DebugMenu.disable_money_checks:
 		_exit_shop()
 
 	if bank < 0:

--- a/faster-than-scrap/code/building_ship/shop.gd
+++ b/faster-than-scrap/code/building_ship/shop.gd
@@ -157,6 +157,9 @@ func _on_bank_change() -> void:
 
 
 func _on_finish_pressed() -> void:
+	if OS.is_debug_build() and not DebugMenu.money_checks:
+		_exit_shop()
+
 	if bank < 0:
 		deny_finish.visible = true
 		deny_finish_label.text = "You cannot leave without paying for modules!"

--- a/faster-than-scrap/code/building_ship/shop.gd
+++ b/faster-than-scrap/code/building_ship/shop.gd
@@ -157,7 +157,7 @@ func _on_bank_change() -> void:
 
 
 func _on_finish_pressed() -> void:
-	if OS.is_debug_build() and DebugMenu.disable_money_checks:
+	if DebugMenu.disable_money_checks:
 		_exit_shop()
 
 	if bank < 0:

--- a/faster-than-scrap/code/debug_menu.gd
+++ b/faster-than-scrap/code/debug_menu.gd
@@ -8,11 +8,20 @@ const BTN_PARENT = NodePath(
 	"ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"
 )
 
-var enable_invincibility: bool = false
-var disable_collisions: bool = false
-var disable_money_checks: bool = false
-var enable_debug_movement: bool = false
-var disable_map_node_checks: bool = false
+var enable_invincibility: bool = false:
+	get: return enable_invincibility and is_debug
+
+var disable_collisions: bool = false:
+	get: return disable_collisions and is_debug
+
+var disable_money_checks: bool = false:
+	get: return disable_money_checks and is_debug
+
+var enable_debug_movement: bool = false:
+	get: return enable_debug_movement and is_debug
+
+var disable_map_node_checks: bool = false:
+	get: return disable_map_node_checks and is_debug
 
 @onready var scene_loader: SceneLoader = $SceneLoader
 @onready var is_debug: bool = OS.is_debug_build()

--- a/faster-than-scrap/code/debug_menu.gd
+++ b/faster-than-scrap/code/debug_menu.gd
@@ -8,6 +8,7 @@ signal toggle_player_collisions
 
 var invincibility: bool = false
 var collisions: bool = true
+var money_checks: bool = true
 
 
 func _ready() -> void:
@@ -37,3 +38,7 @@ func _on_invincibility_pressed() -> void:
 func _on_collisions_pressed() -> void:
 	collisions = not collisions
 	toggle_player_collisions.emit()
+
+
+func _on_money_checks_pressed() -> void:
+	money_checks = not money_checks

--- a/faster-than-scrap/code/debug_menu.gd
+++ b/faster-than-scrap/code/debug_menu.gd
@@ -8,11 +8,15 @@ const BTN_PARENT = NodePath(
 	"ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"
 )
 
+
 var invincibility: bool = false
 var collisions: bool = true
 var money_checks: bool = true
 var debug_movement: bool = false
 var map_node_checks: bool = true
+
+
+@onready var scene_loader: SceneLoader = $SceneLoader
 
 
 func _ready() -> void:
@@ -56,3 +60,7 @@ func _on_debug_movement() -> void:
 
 func _on_map_node_checks_pressed() -> void:
 	map_node_checks = not map_node_checks
+
+
+func _on_map_select_pressed() -> void:
+	scene_loader.load_map_selector_scene()

--- a/faster-than-scrap/code/debug_menu.gd
+++ b/faster-than-scrap/code/debug_menu.gd
@@ -4,6 +4,8 @@ const BTN_PARENT = NodePath(
 	"ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"
 )
 
+var invincibility: bool = false
+
 
 func _ready() -> void:
 	visible = false
@@ -23,3 +25,6 @@ func toggle_menu() -> void:
 	else:
 		GameManager._unpause_entities()
 		visible = false
+
+func _on_invincibility_pressed() -> void:
+	invincibility = not invincibility

--- a/faster-than-scrap/code/debug_menu.gd
+++ b/faster-than-scrap/code/debug_menu.gd
@@ -1,14 +1,17 @@
 extends Control
 
+
+signal toggle_player_collisions
+
+
 const BTN_PARENT = NodePath(
 	"ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"
 )
 
-signal toggle_player_collisions
-
 var invincibility: bool = false
 var collisions: bool = true
 var money_checks: bool = true
+var debug_movement: bool = false
 
 
 func _ready() -> void:
@@ -16,8 +19,10 @@ func _ready() -> void:
 
 
 func _unhandled_input(_event: InputEvent) -> void:
-	if Input.is_action_just_released("debug_menu") and OS.is_debug_build():
-		print("Working!")
+	if not OS.is_debug_build():
+		return
+
+	if Input.is_action_just_released("debug_menu"):
 		toggle_menu()
 
 
@@ -42,3 +47,7 @@ func _on_collisions_pressed() -> void:
 
 func _on_money_checks_pressed() -> void:
 	money_checks = not money_checks
+
+
+func _on_debug_movement() -> void:
+	debug_movement = not debug_movement

--- a/faster-than-scrap/code/debug_menu.gd
+++ b/faster-than-scrap/code/debug_menu.gd
@@ -12,6 +12,7 @@ var invincibility: bool = false
 var collisions: bool = true
 var money_checks: bool = true
 var debug_movement: bool = false
+var map_node_checks: bool = true
 
 
 func _ready() -> void:
@@ -51,3 +52,7 @@ func _on_money_checks_pressed() -> void:
 
 func _on_debug_movement() -> void:
 	debug_movement = not debug_movement
+
+
+func _on_map_node_checks_pressed() -> void:
+	map_node_checks = not map_node_checks

--- a/faster-than-scrap/code/debug_menu.gd
+++ b/faster-than-scrap/code/debug_menu.gd
@@ -1,0 +1,25 @@
+extends Control
+
+const BTN_PARENT = NodePath(
+	"ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"
+)
+
+
+func _ready() -> void:
+	visible = false
+
+
+func _unhandled_input(_event: InputEvent) -> void:
+	if Input.is_action_just_released("debug_menu") and OS.is_debug_build():
+		print("Working!")
+		toggle_menu()
+
+
+func toggle_menu() -> void:
+	if not visible:
+		GameManager._pause_entities()
+		visible = true
+		get_node(BTN_PARENT).get_child(0).grab_focus()
+	else:
+		GameManager._unpause_entities()
+		visible = false

--- a/faster-than-scrap/code/debug_menu.gd
+++ b/faster-than-scrap/code/debug_menu.gd
@@ -8,16 +8,14 @@ const BTN_PARENT = NodePath(
 	"ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"
 )
 
-
-var invincibility: bool = false
-var collisions: bool = true
-var money_checks: bool = true
-var debug_movement: bool = false
-var map_node_checks: bool = true
-
+var enable_invincibility: bool = false
+var disable_collisions: bool = false
+var disable_money_checks: bool = false
+var enable_debug_movement: bool = false
+var disable_map_node_checks: bool = false
 
 @onready var scene_loader: SceneLoader = $SceneLoader
-
+@onready var is_debug: bool = OS.is_debug_build()
 
 func _ready() -> void:
 	visible = false
@@ -42,24 +40,24 @@ func toggle_menu() -> void:
 
 
 func _on_invincibility_pressed() -> void:
-	invincibility = not invincibility
+	enable_invincibility = not enable_invincibility
 
 
 func _on_collisions_pressed() -> void:
-	collisions = not collisions
+	disable_collisions = not disable_collisions
 	toggle_player_collisions.emit()
 
 
 func _on_money_checks_pressed() -> void:
-	money_checks = not money_checks
+	disable_money_checks = not disable_money_checks
 
 
 func _on_debug_movement() -> void:
-	debug_movement = not debug_movement
+	enable_debug_movement = not enable_debug_movement
 
 
 func _on_map_node_checks_pressed() -> void:
-	map_node_checks = not map_node_checks
+	disable_map_node_checks = not disable_map_node_checks
 
 
 func _on_map_select_pressed() -> void:

--- a/faster-than-scrap/code/debug_menu.gd
+++ b/faster-than-scrap/code/debug_menu.gd
@@ -4,7 +4,10 @@ const BTN_PARENT = NodePath(
 	"ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"
 )
 
+signal toggle_player_collisions
+
 var invincibility: bool = false
+var collisions: bool = true
 
 
 func _ready() -> void:
@@ -26,5 +29,11 @@ func toggle_menu() -> void:
 		GameManager._unpause_entities()
 		visible = false
 
+
 func _on_invincibility_pressed() -> void:
 	invincibility = not invincibility
+
+
+func _on_collisions_pressed() -> void:
+	collisions = not collisions
+	toggle_player_collisions.emit()

--- a/faster-than-scrap/code/debug_menu.gd.uid
+++ b/faster-than-scrap/code/debug_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://c32o3v1exc14b

--- a/faster-than-scrap/code/map_select/map_selector.gd
+++ b/faster-than-scrap/code/map_select/map_selector.gd
@@ -40,8 +40,7 @@ func on_leave_button_clicked() -> void:
 	if selected_node == null:
 		return
 
-	if selected_node.is_after_node(active_node) \
-		or (OS.is_debug_build() and DebugMenu.disable_map_node_checks):
+	if selected_node.is_after_node(active_node) or DebugMenu.disable_map_node_checks:
 		MapGenerator.set_node(selected_node)
 		MapSaver.save_map()
 		selected_node.change_scene(scene_loader)

--- a/faster-than-scrap/code/map_select/map_selector.gd
+++ b/faster-than-scrap/code/map_select/map_selector.gd
@@ -41,7 +41,7 @@ func on_leave_button_clicked() -> void:
 		return
 
 	if selected_node.is_after_node(active_node) \
-		or (OS.is_debug_build() and not DebugMenu.map_node_checks):
+		or (OS.is_debug_build() and DebugMenu.disable_map_node_checks):
 		MapGenerator.set_node(selected_node)
 		MapSaver.save_map()
 		selected_node.change_scene(scene_loader)

--- a/faster-than-scrap/code/map_select/map_selector.gd
+++ b/faster-than-scrap/code/map_select/map_selector.gd
@@ -37,7 +37,11 @@ func on_node_clicked(clicked_node: MapNode) -> void:
 
 
 func on_leave_button_clicked() -> void:
-	if selected_node != null and selected_node.is_after_node(active_node):
+	if selected_node == null:
+		return
+
+	if selected_node.is_after_node(active_node) \
+		or (OS.is_debug_build() and not DebugMenu.map_node_checks):
 		MapGenerator.set_node(selected_node)
 		MapSaver.save_map()
 		selected_node.change_scene(scene_loader)

--- a/faster-than-scrap/code/player/player_ship.gd
+++ b/faster-than-scrap/code/player/player_ship.gd
@@ -12,6 +12,7 @@ signal energy_warning(energy: float)
 signal fuel_change(new_value: int)
 
 @export var cockpit: Cockpit
+@export var debug_movement_force: float = 30
 
 ## All modules of the ship (to prevent checking the tree hierarchy).
 ## Mostly used for building phase
@@ -43,9 +44,28 @@ func _ready() -> void:
 
 		if not DebugMenu.collisions:
 			_toggle_collisions()
-	
+
 	energy_max_change.emit(max_energy)
 	_on_energy_change()
+
+
+func _process(delta: float) -> void:
+	super(delta)
+
+	if not (OS.is_debug_build() and DebugMenu.debug_movement):
+		return
+
+	var input_direction = Input.get_vector(
+		"debug_move_left", "debug_move_right", "debug_move_up", "debug_move_down"
+	)
+
+	var force_direction = Vector3(
+		input_direction.x,
+		0,
+		input_direction.y,
+	)
+
+	apply_force(force_direction * debug_movement_force)
 
 
 func on_game_change_state(new_state: GameState.State) -> void:

--- a/faster-than-scrap/code/player/player_ship.gd
+++ b/faster-than-scrap/code/player/player_ship.gd
@@ -42,7 +42,7 @@ func _ready() -> void:
 	if OS.is_debug_build():
 		DebugMenu.toggle_player_collisions.connect(_toggle_collisions)
 
-		if not DebugMenu.collisions:
+		if DebugMenu.disable_collisions:
 			_toggle_collisions()
 
 	energy_max_change.emit(max_energy)
@@ -52,7 +52,7 @@ func _ready() -> void:
 func _process(delta: float) -> void:
 	super(delta)
 
-	if not (OS.is_debug_build() and DebugMenu.debug_movement):
+	if not (OS.is_debug_build() and DebugMenu.enable_debug_movement):
 		return
 
 	var input_direction = Input.get_vector(

--- a/faster-than-scrap/code/player/player_ship.gd
+++ b/faster-than-scrap/code/player/player_ship.gd
@@ -39,7 +39,7 @@ func _ready() -> void:
 	super()
 	GameManager.new_game_state.connect(on_game_change_state)
 
-	if OS.is_debug_build():
+	if DebugMenu.is_debug:
 		DebugMenu.toggle_player_collisions.connect(_toggle_collisions)
 
 		if DebugMenu.disable_collisions:
@@ -52,7 +52,7 @@ func _ready() -> void:
 func _process(delta: float) -> void:
 	super(delta)
 
-	if not (OS.is_debug_build() and DebugMenu.enable_debug_movement):
+	if not DebugMenu.enable_debug_movement:
 		return
 
 	var input_direction = Input.get_vector(

--- a/faster-than-scrap/code/player/player_ship.gd
+++ b/faster-than-scrap/code/player/player_ship.gd
@@ -37,6 +37,13 @@ func _enter_tree() -> void:
 func _ready() -> void:
 	super()
 	GameManager.new_game_state.connect(on_game_change_state)
+
+	if OS.is_debug_build():
+		DebugMenu.toggle_player_collisions.connect(_toggle_collisions)
+
+		if not DebugMenu.collisions:
+			_toggle_collisions()
+	
 	energy_max_change.emit(max_energy)
 	_on_energy_change()
 
@@ -90,3 +97,9 @@ func use_energy(amount: float) -> bool:
 func on_destroy() -> void:
 	super()
 	GameManager.show_death_screen()
+
+
+func _toggle_collisions() -> void:
+	for child in get_children():
+		if child is CollisionShape3D:
+			child.disabled = not child.disabled

--- a/faster-than-scrap/code/scene_loader.gd
+++ b/faster-than-scrap/code/scene_loader.gd
@@ -10,166 +10,166 @@ var default_ship_prefab = preload("res://prefabs/ships/flyable_ship.tscn")
 
 
 func load_main_menu_scene() -> void:
-    GameManager.on_scene_exit()
+	GameManager.on_scene_exit()
 
-    get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
-    GameManager.set_game_state(GameState.State.MAIN_MENU)
+	get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
+	GameManager.set_game_state(GameState.State.MAIN_MENU)
 
 
 func _reset_game() -> void:
-    MapGenerator.reset()
-    MapSaver.reset()
-    CutsceneManager.reset_cutscenes()
-    GameManager.reset()
+	MapGenerator.reset()
+	MapSaver.reset()
+	CutsceneManager.reset_cutscenes()
+	GameManager.reset()
 
 
 #region tutorials
 
 
 func load_movement_tutorial() -> void:
-    _reset_game()
+	_reset_game()
 
-    HudSpawner.spawn_hud = true
-    GameManager.set_game_state(GameState.State.FLY)
-    get_tree().change_scene_to_file("res://scenes/tutorials/basic_movement_tutorial.tscn")
+	HudSpawner.spawn_hud = true
+	GameManager.set_game_state(GameState.State.FLY)
+	get_tree().change_scene_to_file("res://scenes/tutorials/basic_movement_tutorial.tscn")
 
 
 func load_build_tutorial() -> void:
-    load_build_ship_scene(true)
+	load_build_ship_scene(true)
 
 
 #endregion
 
 
 func load_map_selector_scene() -> void:
-    _detach_ship()
-    GameManager.on_scene_exit()
-    get_tree().change_scene_to_file("res://scenes/map_selector.tscn")
-    GameManager.set_game_state(GameState.State.MAP_SELECTOR)
+	_detach_ship()
+	GameManager.on_scene_exit()
+	get_tree().change_scene_to_file("res://scenes/map_selector.tscn")
+	GameManager.set_game_state(GameState.State.MAP_SELECTOR)
 
 
 func load_fly_ship_scene(
-    scene_to_load: PackedScene = null,
-    pos: Vector3 = Vector3.ZERO,
-    rot: Vector3 = Vector3.ZERO,
-    use_saved_pos_rot: bool = true
+	scene_to_load: PackedScene = null,
+	pos: Vector3 = Vector3.ZERO,
+	rot: Vector3 = Vector3.ZERO,
+	use_saved_pos_rot: bool = true
 ) -> void:
-    var attached_fly_scene: bool = false
+	var attached_fly_scene: bool = false
 
-    _detach_ship()
-    GameManager.on_scene_exit()
-    if scene_to_load != null:
-        get_tree().change_scene_to_file(scene_to_load.resource_path)
-    else:
-        if GameManager.game_state == GameState.State.BUILD:
-            attached_fly_scene = MapGenerator.swap_saved_and_current_scene()
-        if not attached_fly_scene:
-            GameManager.get_tree().change_scene_to_file("res://scenes/levels/start_level.tscn")
-            use_saved_pos_rot = false
+	_detach_ship()
+	GameManager.on_scene_exit()
+	if scene_to_load != null:
+		get_tree().change_scene_to_file(scene_to_load.resource_path)
+	else:
+		if GameManager.game_state == GameState.State.BUILD:
+			attached_fly_scene = MapGenerator.swap_saved_and_current_scene()
+		if not attached_fly_scene:
+			GameManager.get_tree().change_scene_to_file("res://scenes/levels/start_level.tscn")
+			use_saved_pos_rot = false
 
-    GameManager.set_game_state(GameState.State.FLY)
+	GameManager.set_game_state(GameState.State.FLY)
 
-    if use_saved_pos_rot and GameManager.player_ship != null:
-            pos = GameManager.player_ship.get_saved_position()
-            rot = GameManager.player_ship.get_saved_rotation()
+	if use_saved_pos_rot and GameManager.player_ship != null:
+			pos = GameManager.player_ship.get_saved_position()
+			rot = GameManager.player_ship.get_saved_rotation()
 
-    _attach_ship_with_hud.call_deferred(pos, rot)
+	_attach_ship_with_hud.call_deferred(pos, rot)
 
-    _set_vortex_preserve(false)
+	_set_vortex_preserve(false)
 
 
 func load_boss_scene(pos: Vector3 = Vector3.ZERO, rot: Vector3 = Vector3.ZERO) -> void:
-    _detach_ship()
-    GameManager.on_scene_exit()
-    get_tree().change_scene_to_file("res://scenes/boss_scene.tscn")
-    GameManager.set_game_state(GameState.State.FLY)
-    _attach_ship_with_hud.call_deferred(pos, rot)
+	_detach_ship()
+	GameManager.on_scene_exit()
+	get_tree().change_scene_to_file("res://scenes/boss_scene.tscn")
+	GameManager.set_game_state(GameState.State.FLY)
+	_attach_ship_with_hud.call_deferred(pos, rot)
 
 
 func load_build_ship_scene(tutorial_version = false) -> void:
-    _set_vortex_preserve(true)
-    GameManager.player_ship.save_position()
-    GameManager.player_ship.save_rotation()
-    _detach_ship()
+	_set_vortex_preserve(true)
+	GameManager.player_ship.save_position()
+	GameManager.player_ship.save_rotation()
+	_detach_ship()
 
-    var attached_build_scene: bool = false
-    if GameManager.game_state == GameState.State.FLY:
-        attached_build_scene = MapGenerator.swap_saved_and_current_scene()
+	var attached_build_scene: bool = false
+	if GameManager.game_state == GameState.State.FLY:
+		attached_build_scene = MapGenerator.swap_saved_and_current_scene()
 
-    GameManager.on_scene_exit()
-    if tutorial_version:
-        GameManager.get_tree().change_scene_to_file(
-            "res://scenes/tutorials/build_ship_tutorial.tscn"
-        )
-    elif not attached_build_scene:
-        GameManager.get_tree().change_scene_to_file("res://scenes/build_ship.tscn")
-    GameManager.set_game_state(GameState.State.BUILD)
-    _attach_ship_with_hud.call_deferred()
+	GameManager.on_scene_exit()
+	if tutorial_version:
+		GameManager.get_tree().change_scene_to_file(
+			"res://scenes/tutorials/build_ship_tutorial.tscn"
+		)
+	elif not attached_build_scene:
+		GameManager.get_tree().change_scene_to_file("res://scenes/build_ship.tscn")
+	GameManager.set_game_state(GameState.State.BUILD)
+	_attach_ship_with_hud.call_deferred()
 
 
 func load_credits_scene() -> void:
-    GameManager.on_scene_exit()
-    get_tree().change_scene_to_file("res://scenes/credits.tscn")
-    GameManager.set_game_state(GameState.State.MAIN_MENU)
+	GameManager.on_scene_exit()
+	get_tree().change_scene_to_file("res://scenes/credits.tscn")
+	GameManager.set_game_state(GameState.State.MAIN_MENU)
 
 
 func load_lore_scene() -> void:
-    _detach_ship()
-    get_tree().change_scene_to_file("res://scenes/lore_start.tscn")
-    GameManager.set_game_state(GameState.State.CUTSCENE)
+	_detach_ship()
+	get_tree().change_scene_to_file("res://scenes/lore_start.tscn")
+	GameManager.set_game_state(GameState.State.CUTSCENE)
 
 
 func load_settings_scene() -> void:
-    get_tree().change_scene_to_file("res://scenes/settings.tscn")
+	get_tree().change_scene_to_file("res://scenes/settings.tscn")
 
 
 ## detach the ship from the scene tree, to preserve it, when it is changed
 func _detach_ship():
-    if GameManager.player_ship == null:
-        return
+	if GameManager.player_ship == null:
+		return
 
-    if GameManager.player_ship.get_parent() == null:
-        return
+	if GameManager.player_ship.get_parent() == null:
+		return
 
-    # detach the ship
-    GameManager.player_ship.get_parent().remove_child(GameManager.player_ship)
+	# detach the ship
+	GameManager.player_ship.get_parent().remove_child(GameManager.player_ship)
 
-    # hud will be destroyed automaticaly
+	# hud will be destroyed automaticaly
 
 
 ## attach the ship to the scene tree
 func _attach_ship_with_hud(pos: Vector3 = Vector3.ZERO, rot: Vector3 = Vector3.ZERO):
-    if GameManager.player_ship == null:
-        GameManager.player_ship = default_ship_prefab.instantiate()
-    # attach ship
-    GameManager.get_tree().root.add_child(GameManager.player_ship)
-    GameManager.ships.push_back(GameManager.player_ship)
+	if GameManager.player_ship == null:
+		GameManager.player_ship = default_ship_prefab.instantiate()
+	# attach ship
+	GameManager.get_tree().root.add_child(GameManager.player_ship)
+	GameManager.ships.push_back(GameManager.player_ship)
 
-    # zero velocity
-    GameManager.player_ship.linear_velocity = Vector3.ZERO
-    GameManager.player_ship.angular_velocity = Vector3.ZERO
+	# zero velocity
+	GameManager.player_ship.linear_velocity = Vector3.ZERO
+	GameManager.player_ship.angular_velocity = Vector3.ZERO
 
-    # set pos and rot
-    GameManager.player_ship.position = pos
-    GameManager.player_ship.rotation = rot
+	# set pos and rot
+	GameManager.player_ship.position = pos
+	GameManager.player_ship.rotation = rot
 
-    HudSpawner.spawn_hud = true
+	HudSpawner.spawn_hud = true
 
 
 ## attach the ship to the scene tree
 func _attach_ship_without_hud():
-    if GameManager.player_ship == null:
-        GameManager.player_ship = default_ship_prefab.instantiate()
-    # attach ship
-    GameManager.get_tree().root.add_child(GameManager.player_ship)
-    GameManager.ships.push_back(GameManager.player_ship)
+	if GameManager.player_ship == null:
+		GameManager.player_ship = default_ship_prefab.instantiate()
+	# attach ship
+	GameManager.get_tree().root.add_child(GameManager.player_ship)
+	GameManager.ships.push_back(GameManager.player_ship)
 
-    # zero velocity
-    GameManager.player_ship.linear_velocity = Vector3.ZERO
-    GameManager.player_ship.angular_velocity = Vector3.ZERO
+	# zero velocity
+	GameManager.player_ship.linear_velocity = Vector3.ZERO
+	GameManager.player_ship.angular_velocity = Vector3.ZERO
 
 
 ## See [member SpaceVortex.preserve_target] for reference
 func _set_vortex_preserve(preserve: bool) -> void:
-    if SpaceVortex.instance != null:
-        SpaceVortex.instance.preserve_target = preserve
+	if SpaceVortex.instance != null:
+		SpaceVortex.instance.preserve_target = preserve

--- a/faster-than-scrap/code/scene_loader.gd
+++ b/faster-than-scrap/code/scene_loader.gd
@@ -10,165 +10,166 @@ var default_ship_prefab = preload("res://prefabs/ships/flyable_ship.tscn")
 
 
 func load_main_menu_scene() -> void:
-	GameManager.on_scene_exit()
+    GameManager.on_scene_exit()
 
-	get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
-	GameManager.set_game_state(GameState.State.MAIN_MENU)
+    get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
+    GameManager.set_game_state(GameState.State.MAIN_MENU)
 
 
 func _reset_game() -> void:
-	MapGenerator.reset()
-	MapSaver.reset()
-	CutsceneManager.reset_cutscenes()
-	GameManager.reset()
+    MapGenerator.reset()
+    MapSaver.reset()
+    CutsceneManager.reset_cutscenes()
+    GameManager.reset()
 
 
 #region tutorials
 
 
 func load_movement_tutorial() -> void:
-	_reset_game()
+    _reset_game()
 
-	HudSpawner.spawn_hud = true
-	GameManager.set_game_state(GameState.State.FLY)
-	get_tree().change_scene_to_file("res://scenes/tutorials/basic_movement_tutorial.tscn")
+    HudSpawner.spawn_hud = true
+    GameManager.set_game_state(GameState.State.FLY)
+    get_tree().change_scene_to_file("res://scenes/tutorials/basic_movement_tutorial.tscn")
 
 
 func load_build_tutorial() -> void:
-	load_build_ship_scene(true)
+    load_build_ship_scene(true)
 
 
 #endregion
 
 
 func load_map_selector_scene() -> void:
-	_detach_ship()
-	GameManager.on_scene_exit()
-	get_tree().change_scene_to_file("res://scenes/map_selector.tscn")
-	GameManager.set_game_state(GameState.State.MAP_SELECTOR)
+    _detach_ship()
+    GameManager.on_scene_exit()
+    get_tree().change_scene_to_file("res://scenes/map_selector.tscn")
+    GameManager.set_game_state(GameState.State.MAP_SELECTOR)
 
 
 func load_fly_ship_scene(
-	scene_to_load: PackedScene = null,
-	pos: Vector3 = Vector3.ZERO,
-	rot: Vector3 = Vector3.ZERO,
-	use_saved_pos_rot: bool = true
+    scene_to_load: PackedScene = null,
+    pos: Vector3 = Vector3.ZERO,
+    rot: Vector3 = Vector3.ZERO,
+    use_saved_pos_rot: bool = true
 ) -> void:
-	var attached_fly_scene: bool = false
+    var attached_fly_scene: bool = false
 
-	_detach_ship()
-	GameManager.on_scene_exit()
-	if scene_to_load != null:
-		get_tree().change_scene_to_file(scene_to_load.resource_path)
-	else:
-		if GameManager.game_state == GameState.State.BUILD:
-			attached_fly_scene = MapGenerator.swap_saved_and_current_scene()
-		if not attached_fly_scene:
-			GameManager.get_tree().change_scene_to_file("res://scenes/levels/start_level.tscn")
-			use_saved_pos_rot = false
+    _detach_ship()
+    GameManager.on_scene_exit()
+    if scene_to_load != null:
+        get_tree().change_scene_to_file(scene_to_load.resource_path)
+    else:
+        if GameManager.game_state == GameState.State.BUILD:
+            attached_fly_scene = MapGenerator.swap_saved_and_current_scene()
+        if not attached_fly_scene:
+            GameManager.get_tree().change_scene_to_file("res://scenes/levels/start_level.tscn")
+            use_saved_pos_rot = false
 
-	GameManager.set_game_state(GameState.State.FLY)
+    GameManager.set_game_state(GameState.State.FLY)
 
-	if use_saved_pos_rot:
-		pos = GameManager.player_ship.get_saved_position()
-		rot = GameManager.player_ship.get_saved_rotation()
-	_attach_ship_with_hud.call_deferred(pos, rot)
+    if use_saved_pos_rot and GameManager.player_ship != null:
+            pos = GameManager.player_ship.get_saved_position()
+            rot = GameManager.player_ship.get_saved_rotation()
 
-	_set_vortex_preserve(false)
+    _attach_ship_with_hud.call_deferred(pos, rot)
+
+    _set_vortex_preserve(false)
 
 
 func load_boss_scene(pos: Vector3 = Vector3.ZERO, rot: Vector3 = Vector3.ZERO) -> void:
-	_detach_ship()
-	GameManager.on_scene_exit()
-	get_tree().change_scene_to_file("res://scenes/boss_scene.tscn")
-	GameManager.set_game_state(GameState.State.FLY)
-	_attach_ship_with_hud.call_deferred(pos, rot)
+    _detach_ship()
+    GameManager.on_scene_exit()
+    get_tree().change_scene_to_file("res://scenes/boss_scene.tscn")
+    GameManager.set_game_state(GameState.State.FLY)
+    _attach_ship_with_hud.call_deferred(pos, rot)
 
 
 func load_build_ship_scene(tutorial_version = false) -> void:
-	_set_vortex_preserve(true)
-	GameManager.player_ship.save_position()
-	GameManager.player_ship.save_rotation()
-	_detach_ship()
+    _set_vortex_preserve(true)
+    GameManager.player_ship.save_position()
+    GameManager.player_ship.save_rotation()
+    _detach_ship()
 
-	var attached_build_scene: bool = false
-	if GameManager.game_state == GameState.State.FLY:
-		attached_build_scene = MapGenerator.swap_saved_and_current_scene()
+    var attached_build_scene: bool = false
+    if GameManager.game_state == GameState.State.FLY:
+        attached_build_scene = MapGenerator.swap_saved_and_current_scene()
 
-	GameManager.on_scene_exit()
-	if tutorial_version:
-		GameManager.get_tree().change_scene_to_file(
-			"res://scenes/tutorials/build_ship_tutorial.tscn"
-		)
-	elif not attached_build_scene:
-		GameManager.get_tree().change_scene_to_file("res://scenes/build_ship.tscn")
-	GameManager.set_game_state(GameState.State.BUILD)
-	_attach_ship_with_hud.call_deferred()
+    GameManager.on_scene_exit()
+    if tutorial_version:
+        GameManager.get_tree().change_scene_to_file(
+            "res://scenes/tutorials/build_ship_tutorial.tscn"
+        )
+    elif not attached_build_scene:
+        GameManager.get_tree().change_scene_to_file("res://scenes/build_ship.tscn")
+    GameManager.set_game_state(GameState.State.BUILD)
+    _attach_ship_with_hud.call_deferred()
 
 
 func load_credits_scene() -> void:
-	GameManager.on_scene_exit()
-	get_tree().change_scene_to_file("res://scenes/credits.tscn")
-	GameManager.set_game_state(GameState.State.MAIN_MENU)
+    GameManager.on_scene_exit()
+    get_tree().change_scene_to_file("res://scenes/credits.tscn")
+    GameManager.set_game_state(GameState.State.MAIN_MENU)
 
 
 func load_lore_scene() -> void:
-	_detach_ship()
-	get_tree().change_scene_to_file("res://scenes/lore_start.tscn")
-	GameManager.set_game_state(GameState.State.CUTSCENE)
+    _detach_ship()
+    get_tree().change_scene_to_file("res://scenes/lore_start.tscn")
+    GameManager.set_game_state(GameState.State.CUTSCENE)
 
 
 func load_settings_scene() -> void:
-	get_tree().change_scene_to_file("res://scenes/settings.tscn")
+    get_tree().change_scene_to_file("res://scenes/settings.tscn")
 
 
 ## detach the ship from the scene tree, to preserve it, when it is changed
 func _detach_ship():
-	if GameManager.player_ship == null:
-		return
+    if GameManager.player_ship == null:
+        return
 
-	if GameManager.player_ship.get_parent() == null:
-		return
+    if GameManager.player_ship.get_parent() == null:
+        return
 
-	# detach the ship
-	GameManager.player_ship.get_parent().remove_child(GameManager.player_ship)
+    # detach the ship
+    GameManager.player_ship.get_parent().remove_child(GameManager.player_ship)
 
-	# hud will be destroyed automaticaly
+    # hud will be destroyed automaticaly
 
 
 ## attach the ship to the scene tree
 func _attach_ship_with_hud(pos: Vector3 = Vector3.ZERO, rot: Vector3 = Vector3.ZERO):
-	if GameManager.player_ship == null:
-		GameManager.player_ship = default_ship_prefab.instantiate()
-	# attach ship
-	GameManager.get_tree().root.add_child(GameManager.player_ship)
-	GameManager.ships.push_back(GameManager.player_ship)
+    if GameManager.player_ship == null:
+        GameManager.player_ship = default_ship_prefab.instantiate()
+    # attach ship
+    GameManager.get_tree().root.add_child(GameManager.player_ship)
+    GameManager.ships.push_back(GameManager.player_ship)
 
-	# zero velocity
-	GameManager.player_ship.linear_velocity = Vector3.ZERO
-	GameManager.player_ship.angular_velocity = Vector3.ZERO
+    # zero velocity
+    GameManager.player_ship.linear_velocity = Vector3.ZERO
+    GameManager.player_ship.angular_velocity = Vector3.ZERO
 
-	# set pos and rot
-	GameManager.player_ship.position = pos
-	GameManager.player_ship.rotation = rot
+    # set pos and rot
+    GameManager.player_ship.position = pos
+    GameManager.player_ship.rotation = rot
 
-	HudSpawner.spawn_hud = true
+    HudSpawner.spawn_hud = true
 
 
 ## attach the ship to the scene tree
 func _attach_ship_without_hud():
-	if GameManager.player_ship == null:
-		GameManager.player_ship = default_ship_prefab.instantiate()
-	# attach ship
-	GameManager.get_tree().root.add_child(GameManager.player_ship)
-	GameManager.ships.push_back(GameManager.player_ship)
+    if GameManager.player_ship == null:
+        GameManager.player_ship = default_ship_prefab.instantiate()
+    # attach ship
+    GameManager.get_tree().root.add_child(GameManager.player_ship)
+    GameManager.ships.push_back(GameManager.player_ship)
 
-	# zero velocity
-	GameManager.player_ship.linear_velocity = Vector3.ZERO
-	GameManager.player_ship.angular_velocity = Vector3.ZERO
+    # zero velocity
+    GameManager.player_ship.linear_velocity = Vector3.ZERO
+    GameManager.player_ship.angular_velocity = Vector3.ZERO
 
 
 ## See [member SpaceVortex.preserve_target] for reference
 func _set_vortex_preserve(preserve: bool) -> void:
-	if SpaceVortex.instance != null:
-		SpaceVortex.instance.preserve_target = preserve
+    if SpaceVortex.instance != null:
+        SpaceVortex.instance.preserve_target = preserve

--- a/faster-than-scrap/code/ship/modules/module.gd
+++ b/faster-than-scrap/code/ship/modules/module.gd
@@ -115,7 +115,7 @@ func _on_release(_delta: float) -> void:
 
 
 func take_damage(damage: Damage) -> void:
-	if OS.is_debug_build() and DebugMenu.enable_invincibility:
+	if DebugMenu.enable_invincibility:
 		return
 
 	hp -= damage.value

--- a/faster-than-scrap/code/ship/modules/module.gd
+++ b/faster-than-scrap/code/ship/modules/module.gd
@@ -115,6 +115,9 @@ func _on_release(_delta: float) -> void:
 
 
 func take_damage(damage: Damage) -> void:
+	if OS.is_debug_build() and DebugMenu.invincibility:
+		return
+	
 	hp -= damage.value
 	update_sprite()
 	if hp <= 0:

--- a/faster-than-scrap/code/ship/modules/module.gd
+++ b/faster-than-scrap/code/ship/modules/module.gd
@@ -115,9 +115,9 @@ func _on_release(_delta: float) -> void:
 
 
 func take_damage(damage: Damage) -> void:
-	if OS.is_debug_build() and DebugMenu.invincibility:
+	if OS.is_debug_build() and DebugMenu.enable_invincibility:
 		return
-	
+
 	hp -= damage.value
 	update_sprite()
 	if hp <= 0:

--- a/faster-than-scrap/code/ship/modules/module.gd
+++ b/faster-than-scrap/code/ship/modules/module.gd
@@ -10,7 +10,7 @@ signal deactivated
 signal damaged
 signal destroyed
 
-const NOT_ACTIVABLE_KEYS: Array[Key] = [KEY_ENTER, KEY_ESCAPE]
+var NOT_ACTIVABLE_KEYS: Array[Key] = [KEY_ENTER, KEY_ESCAPE]
 
 const EXPLOSION_MAX_RANDOM_SPEED = 2
 const EXPLOSION_MAX_RANDOM_ROTATION = 1
@@ -48,31 +48,39 @@ var module_rigidbody_prefab = preload("res://prefabs/modules/module_rigidbody.ts
 var activation_key_saved: Key = KEY_NONE
 
 var module_explosion_prefab = preload(
-	"res://prefabs/vfx/particles/timed_particles/module_explosion.tscn"
+    "res://prefabs/vfx/particles/timed_particles/module_explosion.tscn"
 )
 
 
+func keycode_from_input_map(event_name: String) -> Key:
+    return (InputMap.action_get_events(event_name)[0] as InputEventKey) \
+            .get_physical_keycode_with_modifiers()
+
+
 func _ready() -> void:
-	activation_key_saved = activation_key
-	_on_key_change()
-	update_sprite()
+    if OS.is_debug_build():
+        NOT_ACTIVABLE_KEYS.append(keycode_from_input_map("debug_menu"))
+    
+    activation_key_saved = activation_key
+    _on_key_change()
+    update_sprite()
 
 
 func _process(_delta: float) -> void:
-	if was_key_pressed:
-		if Input.is_key_pressed(activation_key):
-			_on_key(_delta)
-		else:
-			was_key_pressed = false
-			_on_release(_delta)
-	else:
-		if Input.is_key_pressed(activation_key):
-			_on_key_press(_delta)
-			_on_key(_delta)
-			was_key_pressed = true
+    if was_key_pressed:
+        if Input.is_key_pressed(activation_key):
+            _on_key(_delta)
+        else:
+            was_key_pressed = false
+            _on_release(_delta)
+    else:
+        if Input.is_key_pressed(activation_key):
+            _on_key_press(_delta)
+            _on_key(_delta)
+            was_key_pressed = true
 
-	if label != null:
-		label.rotation.y = -global_rotation.y
+    if label != null:
+        label.rotation.y = -global_rotation.y
 
 
 # virtual functions
@@ -80,25 +88,25 @@ func _process(_delta: float) -> void:
 
 ## Called on one frame, when [member Module.activation_key] has just been pressed
 func _on_key_press(_delta: float) -> void:
-	pass
+    pass
 
 
 ## Called on every frame when [member Module.activation_key] is pressed
 func _on_key(_delta: float) -> void:
-	pass
+    pass
 
 
 ## Called on one frame, when [member Module.activation_key] has just been released
 func _on_release(_delta: float) -> void:
-	pass
+    pass
 
 
 func take_damage(damage: Damage) -> void:
-	hp -= damage.value
-	update_sprite()
-	if hp <= 0:
-		_on_destroy()
-	damaged.emit()
+    hp -= damage.value
+    update_sprite()
+    if hp <= 0:
+        _on_destroy()
+    damaged.emit()
 
 
 func heal(value: float) -> void:
@@ -108,23 +116,23 @@ func heal(value: float) -> void:
 
 
 func update_sprite() -> void:
-	if sprite != null:
-		sprite.modulate = lerp(dead_color, healthy_color, hp / max_hp)
+    if sprite != null:
+        sprite.modulate = lerp(dead_color, healthy_color, hp / max_hp)
 
 
 ## Destroy self and detach children
 func _on_destroy() -> void:
-	if parent_module != null:
-		parent_module.child_modules.erase(self)
-	_explode()
+    if parent_module != null:
+        parent_module.child_modules.erase(self)
+    _explode()
 
 	detach_all_children(global_position)
 
-	if parent_module != null:
-		on_detach()
+    if parent_module != null:
+        on_detach()
 
-	queue_free()  # delete self as an object
-	destroyed.emit()
+    queue_free()  # delete self as an object
+    destroyed.emit()
 
 
 func detach_all_children(explosion_center: Vector3) -> void:
@@ -160,105 +168,105 @@ func detach_all_children(explosion_center: Vector3) -> void:
 
 ## Called when the module is attached to the ship
 func on_attach() -> void:
-	pass
+    pass
 
 
 ## Called just before the module is detached from the ship
 func on_detach() -> void:
-	pass
+    pass
 
 
 ## Called when the module is attached to a different part of the ship than it previously was
 func on_reattach() -> void:
-	pass
+    pass
 
 
 func deactivate() -> void:
-	activation_key_saved = activation_key
-	activation_key = KEY_NONE
+    activation_key_saved = activation_key
+    activation_key = KEY_NONE
 
 
 func activate() -> void:
-	activation_key = activation_key_saved
+    activation_key = activation_key_saved
 
 
 func _explode() -> void:
-	# create particles object
-	var explosion: TimedParticle = module_explosion_prefab.instantiate()
-	get_tree().current_scene.add_child(explosion)
-	explosion.global_position = global_position
+    # create particles object
+    var explosion: TimedParticle = module_explosion_prefab.instantiate()
+    get_tree().current_scene.add_child(explosion)
+    explosion.global_position = global_position
 
 
 func detachable() -> bool:
-	return true
+    return true
 
 
 func change_key(key: Key) -> void:
-	if activation_key == 0:
-		activation_key_saved = key
-	else:
-		activation_key = key
-	_on_key_change()
+    if activation_key == 0:
+        activation_key_saved = key
+    else:
+        activation_key = key
+    _on_key_change()
 
 
 func _on_key_change() -> void:
-	var text: String = OS.get_keycode_string(activation_key_saved)
-	if label != null:
-		label.text = text
-		## one line text up to 3 characters
-		if text.length() <= 0:
-			return
-		if text.length() <= 3:
-			label.font_size = int(160.0 / text.length())
-		else:
-			label.font_size = int(160.0 / text.length() * 2)
+    var text: String = OS.get_keycode_string(activation_key_saved)
+    if label != null:
+        label.text = text
+        ## one line text up to 3 characters
+        if text.length() <= 0:
+            return
+        if text.length() <= 3:
+            label.font_size = int(160.0 / text.length())
+        else:
+            label.font_size = int(160.0 / text.length() * 2)
 
 
 func has_child_module() -> bool:
-	return child_modules.size() > 0
+    return child_modules.size() > 0
 
 
 func set_ship_reference(ship_ref: Ship) -> void:
-	ship = ship_ref
+    ship = ship_ref
 
 
 ## Returns the node3D which is the center of the attach point.
 ## Foward vector of that returned node indicates the forward rotation of the module
 ## when attached to that point
 func get_attach_point(index: int) -> Node3D:
-	if attach_points.size() == 0:
-		printerr("MODULE HAS NO ATTACH POINTS")
-	return attach_points[index % attach_points.size()]
+    if attach_points.size() == 0:
+        printerr("MODULE HAS NO ATTACH POINTS")
+    return attach_points[index % attach_points.size()]
 
 
 ## Create an Area3D object which is a copy of module tree
 ## with the only difference of a root not being a module (rigidbody3d).
 ## All children are copied!
 func create_ghost() -> ModuleGhost:
-	# create ghost in scene
-	var ghost := ModuleGhost.new()
-	get_tree().root.add_child(ghost)
-	ghost.name = "ghost"
-	ghost.global_position = global_position
+    # create ghost in scene
+    var ghost := ModuleGhost.new()
+    get_tree().root.add_child(ghost)
+    ghost.name = "ghost"
+    ghost.global_position = global_position
 
-	# duplicate module
-	var duplicate_node: Node3D = self.duplicate()
-	ghost.add_child(duplicate_node)
-	duplicate_node.position = Vector3.ZERO
-	duplicate_node.rotation = Vector3.ZERO
-	duplicate_node.prize = 0
-	ghost.module_to_ignore = self
+    # duplicate module
+    var duplicate_node: Node3D = self.duplicate()
+    ghost.add_child(duplicate_node)
+    duplicate_node.position = Vector3.ZERO
+    duplicate_node.rotation = Vector3.ZERO
+    duplicate_node.prize = 0
+    ghost.module_to_ignore = self
 
-	return ghost
+    return ghost
 
 
 ## Return all children (even indirect) modules of a given node.
 static func find_all_modules(node: Node) -> Array[Module]:
-	var result = []
-	for child in node.get_children():
-		if child is Module:
-			result.append(child)
-		result.append_array(find_all_modules(child))  # Recurse
-	var modules: Array[Module] = []
-	modules.assign(result)  # create module typed array
-	return modules
+    var result = []
+    for child in node.get_children():
+        if child is Module:
+            result.append(child)
+        result.append_array(find_all_modules(child))  # Recurse
+    var modules: Array[Module] = []
+    modules.assign(result)  # create module typed array
+    return modules

--- a/faster-than-scrap/code/ship/modules/module.gd
+++ b/faster-than-scrap/code/ship/modules/module.gd
@@ -63,7 +63,7 @@ func reserve_keys_from_actions(actions: Array[String]):
 
 
 func reserve_keys():
-	if OS.is_debug_build():
+	if DebugMenu.is_debug:
 		reserve_keys_from_actions(["debug_menu"])
 
 	reserve_keys_from_actions([

--- a/faster-than-scrap/code/ship/modules/weapons/weapon_module.gd
+++ b/faster-than-scrap/code/ship/modules/weapons/weapon_module.gd
@@ -40,7 +40,7 @@ func _on_release(_delta: float) -> void:
 
 
 func _recoil(force_multiplier: float) -> void:
-	if OS.is_debug_build() and DebugMenu.enable_debug_movement:
+	if DebugMenu.enable_debug_movement:
 		return
 
 	ship.apply_force(

--- a/faster-than-scrap/code/ship/modules/weapons/weapon_module.gd
+++ b/faster-than-scrap/code/ship/modules/weapons/weapon_module.gd
@@ -40,7 +40,7 @@ func _on_release(_delta: float) -> void:
 
 
 func _recoil(force_multiplier: float) -> void:
-	if OS.is_debug_build() and DebugMenu.debug_movement:
+	if OS.is_debug_build() and DebugMenu.enable_debug_movement:
 		return
 
 	ship.apply_force(

--- a/faster-than-scrap/code/ship/modules/weapons/weapon_module.gd
+++ b/faster-than-scrap/code/ship/modules/weapons/weapon_module.gd
@@ -40,6 +40,9 @@ func _on_release(_delta: float) -> void:
 
 
 func _recoil(force_multiplier: float) -> void:
+	if OS.is_debug_build() and DebugMenu.debug_movement:
+		return
+
 	ship.apply_force(
 		weapon.global_basis.z * force_multiplier, global_position - ship.global_position
 	)

--- a/faster-than-scrap/code/singletons/debug_menu.tscn
+++ b/faster-than-scrap/code/singletons/debug_menu.tscn
@@ -68,5 +68,12 @@ theme_override_font_sizes/font_size = 30
 toggle_mode = true
 text = "Disable player collision"
 
+[node name="Btn 3" type="Button" parent="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+toggle_mode = true
+text = "Disable money checks"
+
 [connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 1" to="." method="_on_invincibility_pressed"]
 [connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 2" to="." method="_on_collisions_pressed"]
+[connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 3" to="." method="_on_money_checks_pressed"]

--- a/faster-than-scrap/code/singletons/debug_menu.tscn
+++ b/faster-than-scrap/code/singletons/debug_menu.tscn
@@ -1,12 +1,17 @@
-[gd_scene format=3 uid="uid://bkfxe1nlfsvs1"]
+[gd_scene load_steps=2 format=3 uid="uid://dscrc7veyfr8e"]
+
+[ext_resource type="Script" uid="uid://c32o3v1exc14b" path="res://code/debug_menu.gd" id="1_r546s"]
 
 [node name="DebugMenu" type="Control"]
+process_mode = 3
+z_index = 999
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_r546s")
 
 [node name="ColorRect" type="ColorRect" parent="."]
 layout_mode = 1
@@ -15,7 +20,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-color = Color(0.768627, 0, 0, 0.498039)
+color = Color(0.501961, 0, 0, 0.843137)
 
 [node name="MarginContainer" type="MarginContainer" parent="ColorRect"]
 layout_mode = 1

--- a/faster-than-scrap/code/singletons/debug_menu.tscn
+++ b/faster-than-scrap/code/singletons/debug_menu.tscn
@@ -61,7 +61,7 @@ alignment = 1
 layout_mode = 2
 theme_override_font_sizes/font_size = 30
 toggle_mode = true
-text = "Toggle player invincibility"
+text = "Enable invincibility"
 
 [node name="Btn 2" type="Button" parent="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"]
 layout_mode = 2

--- a/faster-than-scrap/code/singletons/debug_menu.tscn
+++ b/faster-than-scrap/code/singletons/debug_menu.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://dscrc7veyfr8e"]
+[gd_scene load_steps=3 format=3 uid="uid://dscrc7veyfr8e"]
 
 [ext_resource type="Script" uid="uid://c32o3v1exc14b" path="res://code/debug_menu.gd" id="1_r546s"]
+[ext_resource type="Script" uid="uid://16i5n2yxnlsr" path="res://code/scene_loader.gd" id="2_fmo40"]
 
 [node name="DebugMenu" type="Control"]
 process_mode = 3
@@ -86,8 +87,17 @@ theme_override_font_sizes/font_size = 30
 toggle_mode = true
 text = "Disable map node checks"
 
+[node name="Btn 6" type="Button" parent="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+text = "Enter map select screen"
+
+[node name="SceneLoader" type="Node" parent="."]
+script = ExtResource("2_fmo40")
+
 [connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 1" to="." method="_on_invincibility_pressed"]
 [connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 2" to="." method="_on_collisions_pressed"]
 [connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 3" to="." method="_on_money_checks_pressed"]
 [connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 4" to="." method="_on_debug_movement"]
 [connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 5" to="." method="_on_map_node_checks_pressed"]
+[connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 6" to="." method="_on_map_select_pressed"]

--- a/faster-than-scrap/code/singletons/debug_menu.tscn
+++ b/faster-than-scrap/code/singletons/debug_menu.tscn
@@ -74,6 +74,13 @@ theme_override_font_sizes/font_size = 30
 toggle_mode = true
 text = "Disable money checks"
 
+[node name="Btn 4" type="Button" parent="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+toggle_mode = true
+text = "Enable debug movement"
+
 [connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 1" to="." method="_on_invincibility_pressed"]
 [connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 2" to="." method="_on_collisions_pressed"]
 [connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 3" to="." method="_on_money_checks_pressed"]
+[connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 4" to="." method="_on_debug_movement"]

--- a/faster-than-scrap/code/singletons/debug_menu.tscn
+++ b/faster-than-scrap/code/singletons/debug_menu.tscn
@@ -59,9 +59,7 @@ alignment = 1
 [node name="Btn 1" type="Button" parent="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 30
-text = "Test button 1"
+toggle_mode = true
+text = "Toggle player invincibility"
 
-[node name="Btn 2" type="Button" parent="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 30
-text = "Test button 2"
+[connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 1" to="." method="_on_invincibility_pressed"]

--- a/faster-than-scrap/code/singletons/debug_menu.tscn
+++ b/faster-than-scrap/code/singletons/debug_menu.tscn
@@ -80,7 +80,14 @@ theme_override_font_sizes/font_size = 30
 toggle_mode = true
 text = "Enable debug movement"
 
+[node name="Btn 5" type="Button" parent="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+toggle_mode = true
+text = "Disable map node checks"
+
 [connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 1" to="." method="_on_invincibility_pressed"]
 [connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 2" to="." method="_on_collisions_pressed"]
 [connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 3" to="." method="_on_money_checks_pressed"]
 [connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 4" to="." method="_on_debug_movement"]
+[connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 5" to="." method="_on_map_node_checks_pressed"]

--- a/faster-than-scrap/code/singletons/debug_menu.tscn
+++ b/faster-than-scrap/code/singletons/debug_menu.tscn
@@ -62,4 +62,11 @@ theme_override_font_sizes/font_size = 30
 toggle_mode = true
 text = "Toggle player invincibility"
 
+[node name="Btn 2" type="Button" parent="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+toggle_mode = true
+text = "Disable player collision"
+
 [connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 1" to="." method="_on_invincibility_pressed"]
+[connection signal="pressed" from="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer/Btn 2" to="." method="_on_collisions_pressed"]

--- a/faster-than-scrap/prefabs/debug_menu.tscn
+++ b/faster-than-scrap/prefabs/debug_menu.tscn
@@ -1,0 +1,62 @@
+[gd_scene format=3 uid="uid://bkfxe1nlfsvs1"]
+
+[node name="DebugMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="ColorRect" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.768627, 0, 0, 0.498039)
+
+[node name="MarginContainer" type="MarginContainer" parent="ColorRect"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 50
+theme_override_constants/margin_top = 50
+theme_override_constants/margin_right = 50
+theme_override_constants/margin_bottom = 50
+
+[node name="VBoxContainer2" type="VBoxContainer" parent="ColorRect/MarginContainer"]
+layout_mode = 2
+alignment = 1
+
+[node name="Title" type="RichTextLabel" parent="ColorRect/MarginContainer/VBoxContainer2"]
+layout_mode = 2
+size_flags_vertical = 0
+theme_override_font_sizes/normal_font_size = 32
+theme_override_font_sizes/bold_font_size = 32
+bbcode_enabled = true
+text = "[b]Debug menu[/b]"
+fit_content = true
+horizontal_alignment = 1
+
+[node name="CenterContainer" type="CenterContainer" parent="ColorRect/MarginContainer/VBoxContainer2"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="VBoxContainer" type="VBoxContainer" parent="ColorRect/MarginContainer/VBoxContainer2/CenterContainer"]
+layout_mode = 2
+alignment = 1
+
+[node name="Btn 1" type="Button" parent="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+text = "Test button 1"
+
+[node name="Btn 2" type="Button" parent="ColorRect/MarginContainer/VBoxContainer2/CenterContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+text = "Test button 2"

--- a/faster-than-scrap/project.godot
+++ b/faster-than-scrap/project.godot
@@ -104,6 +104,11 @@ use_fuel={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194310,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+debug_menu={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194334,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 

--- a/faster-than-scrap/project.godot
+++ b/faster-than-scrap/project.godot
@@ -110,6 +110,26 @@ debug_menu={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194334,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+debug_move_up={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
+]
+}
+debug_move_down={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
+]
+}
+debug_move_left={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"location":0,"echo":false,"script":null)
+]
+}
+debug_move_right={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 

--- a/faster-than-scrap/project.godot
+++ b/faster-than-scrap/project.godot
@@ -17,6 +17,7 @@ config/icon="res://icon.svg"
 
 [autoload]
 
+DebugMenu="*res://code/singletons/debug_menu.tscn"
 GameManager="*res://prefabs/singletons/game_manager.tscn"
 MissionManager="*res://prefabs/singletons/mission_manager.tscn"
 BossManager="*res://code/singletons/boss_manager.gd"


### PR DESCRIPTION
Currently adding new features is cumbersome because it's hard to test them. This pull request adds a simple debug menu that allows for
- faster map traversal by:
  - disabling collision
  - enabling debug movement
- faster ship prototyping by:
  - disabling money balance checks in the workshop
- easier map exploration by:
  - enabling invincibility mode
- Easy level testing by:
  - skipping directly to level select
  - disabling node validity checks.

Usage notes:
- The debug menu is only available on debug builds
- To use the debug menu press <F3> on your keyboard.
- The debug movement option remaps WASD keys to directly control the ship.

As a side effect, this pull request also fixes a bug where changing key bindings in the Input Map doesn't get reflected in key validity checks when binding keys to modules during ship building.