### PR TITLE
Fix pop-up window in build ship scene

### DIFF
--- a/faster-than-scrap/scenes/tutorials/build_ship_tutorial.tscn
+++ b/faster-than-scrap/scenes/tutorials/build_ship_tutorial.tscn
@@ -465,6 +465,7 @@ play_on_ready = true
 [connection signal="on_module_attach" from="ShipBuilder" to="Shop" method="_on_module_attached"]
 [connection signal="on_module_detach" from="ShipBuilder" to="Shop" method="_on_ship_builder_on_module_detach"]
 [connection signal="on_module_hover" from="ShipBuilder" to="Shop" method="_on_ship_builder_on_module_select"]
+[connection signal="pressed" from="ShipBuilder/Control/Deny finish/Color_Rect/Confirm" to="Shop" method="_on_confirm_pressed"]
 [connection signal="pressed" from="ShipBuilder/Control/Confirm finish/Color_Rect/Confirm" to="ShipBuilder" method="_on_confirm_pressed"]
 [connection signal="pressed" from="ShipBuilder/Control/Confirm finish/Color_Rect/Deny" to="ShipBuilder" method="_on_deny_pressed"]
 [connection signal="pressed" from="ShipBuilder/Control/Finish" to="Shop" method="_on_finish_pressed"]


### PR DESCRIPTION
The deny finish pop-up window couldn't be closed in the build ship tutorial scene.
A fix has been made by connecting a missing signal.