### PR TITLE
Freeze ship

### DIFF
--- a/faster-than-scrap/code/building_ship/ship_builder.gd
+++ b/faster-than-scrap/code/building_ship/ship_builder.gd
@@ -65,11 +65,11 @@ func _ready() -> void:
 
 
 func _enter_tree() -> void:
-	freeze_ship(true)
+	set_freeze_mode(true)
 
 
 func _exit_tree() -> void:
-	freeze_ship(false)
+	set_freeze_mode(false)
 
 
 # ---------------mouse ---------------------------------------------
@@ -502,5 +502,5 @@ func _on_deny_pressed() -> void:
 	confirm_finish_message.visible = false
 
 
-func freeze_ship(if_freeze: bool):
-	GameManager.player_ship.freeze = if_freeze
+func set_freeze_mode(is_frozen: bool):
+	GameManager.player_ship.freeze = is_frozen

--- a/faster-than-scrap/code/building_ship/ship_builder.gd
+++ b/faster-than-scrap/code/building_ship/ship_builder.gd
@@ -64,6 +64,14 @@ func _ready() -> void:
 		ignore_rid.push_back(ig.get_rid())
 
 
+func _enter_tree() -> void:
+	freeze_ship(true)
+
+
+func _exit_tree() -> void:
+	freeze_ship(false)
+
+
 # ---------------mouse ---------------------------------------------
 func _update_mouse_3d_position():
 	var camera = get_viewport().get_camera_3d()
@@ -492,3 +500,7 @@ func _on_confirm_pressed() -> void:
 
 func _on_deny_pressed() -> void:
 	confirm_finish_message.visible = false
+
+
+func freeze_ship(if_freeze: bool):
+	GameManager.player_ship.freeze = if_freeze

--- a/faster-than-scrap/code/ship/modules/weapons/weapon_module.gd
+++ b/faster-than-scrap/code/ship/modules/weapons/weapon_module.gd
@@ -48,3 +48,8 @@ func _recoil(force_multiplier: float) -> void:
 func set_ship_reference(ship_ref: Ship) -> void:
 	super(ship_ref)
 	weapon.ship = ship_ref
+
+
+func deactivate() -> void:
+	super()
+	weapon.force_deactivate()

--- a/faster-than-scrap/code/vfx/beam_vfx_logic.gd
+++ b/faster-than-scrap/code/vfx/beam_vfx_logic.gd
@@ -8,13 +8,15 @@ const END_ANIM: String = "Off"
 
 var animation_check: bool
 
+
 func _ready() -> void:
 	animation_check = player.has_animation(START_ANIM) && player.has_animation(END_ANIM)
 	if animation_check:
 		player.play(START_ANIM)
 
+
 func _notification(notification):
-	if (notification == NOTIFICATION_PREDELETE):
+	if notification == NOTIFICATION_PREDELETE and get_parent() != null:
 		holder.reparent(get_parent())
 		if animation_check:
 			player.play(END_ANIM)

--- a/faster-than-scrap/code/vfx/leave_animation.gd
+++ b/faster-than-scrap/code/vfx/leave_animation.gd
@@ -13,26 +13,28 @@ extends Node3D
 @export var jump_time: float = 1.0
 
 @export var downwards_curve: Curve
-@export var minimum_y: float = - 10
+@export var minimum_y: float = -10
 
 var player: PlayerShip
 var animating = false
-var anim_timer: float =0
+var anim_timer: float = 0
 var saved_transform: Transform3D
 
 var ending: Callable
 ## variable that block multiple activation of this animation
 var callable: bool = true
 
+
 func _ready() -> void:
 	player = GameManager.player_ship
-	prepare_particles.speed_scale = 6/(prepare_time + jump_time)
+	prepare_particles.speed_scale = 6 / (prepare_time + jump_time)
+
 
 func _process(_delta: float) -> void:
 	if animating:
 		anim_timer += _delta
 		player.transform = saved_transform
-		var sample = downwards_curve.sample(anim_timer/(jump_time + prepare_time))
+		var sample = downwards_curve.sample(anim_timer / (jump_time + prepare_time))
 		player.position += Vector3.UP * minimum_y * sample
 
 
@@ -41,7 +43,7 @@ func start_animation(ending_method: Callable) -> void:
 		callable = false
 		ending = ending_method
 		anim_player.play(prepare_anim_name, -1, 1 / prepare_time)
-		animating = true;
+		animating = true
 		saved_transform = player.transform
 		anim_timer = 0
 

--- a/faster-than-scrap/code/weapons/base_weapon.gd
+++ b/faster-than-scrap/code/weapons/base_weapon.gd
@@ -43,5 +43,9 @@ func try_deactivate() -> bool:
 	return false
 
 
+func force_deactivate():
+	pass
+
+
 func _spawn_projectile() -> Node3D:
 	return projectile.instantiate()

--- a/faster-than-scrap/code/weapons/constant_fire_weapon.gd
+++ b/faster-than-scrap/code/weapons/constant_fire_weapon.gd
@@ -51,3 +51,10 @@ func try_deactivate() -> bool:
 	if muzzle_flash != null:
 		muzzle_flash.emitting = false
 	return true
+
+
+func force_deactivate() -> void:
+	if active_projectile == null:
+		return
+	active_projectile.get_parent().remove_child(active_projectile)
+	active_projectile.queue_free()

--- a/faster-than-scrap/scenes/build_ship.tscn
+++ b/faster-than-scrap/scenes/build_ship.tscn
@@ -451,6 +451,7 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="RepairModules" type="Button" parent="Control"]
+layout_mode = 0
 offset_left = 8.0
 offset_top = 391.0
 offset_right = 248.0


### PR DESCRIPTION
#241 
Bug - after changing to the ship building scene the ship could still be moving for a while with turned on thrusters.
It is fixed by freezing the ship and destroying thrusters projectiles with `force_deactivate()`.