### PR TITLE
Many collision bug fixes

### DIFF
--- a/faster-than-scrap/code/collision_damage_calculator.gd
+++ b/faster-than-scrap/code/collision_damage_calculator.gd
@@ -27,10 +27,26 @@ var pre_collision_velocity: Vector3
 
 
 func _ready() -> void:
+	GameManager.new_game_state.connect(_on_game_manager_new_game_state)
+
+	find_calculated_body()
+
+
+func _on_game_manager_new_game_state(_new_state: GameState.State):
+	find_calculated_body()
+
+
+func find_calculated_body():
+	if calculated_body != null:
+		calculated_body.body_shape_entered.disconnect(_find_parent_collision)
+	calculated_body = null
+
 	# check if parent is PhysicsBody3D, to make it work with module ghosts
 	if shape.get_parent_node_3d() is not PhysicsBody3D:
 		set_process(false)
 		return
+	else:
+		set_process(true)
 
 	calculated_body = shape.get_parent_node_3d()
 	calculated_body.set_meta("collision_damage_calculator", self)
@@ -74,7 +90,7 @@ func _find_parent_collision(
 
 
 func calculate_damage(me: Node, oponent: Node) -> Damage:
-	var oponet_calculator: Node
+	var oponet_calculator
 	if oponent.has_meta("collision_damage_calculator"):
 		oponet_calculator = oponent.get_meta("collision_damage_calculator")
 	else:

--- a/faster-than-scrap/code/collision_damage_calculator.gd
+++ b/faster-than-scrap/code/collision_damage_calculator.gd
@@ -45,8 +45,7 @@ func find_calculated_body():
 	if shape.get_parent_node_3d() is not PhysicsBody3D:
 		set_process(false)
 		return
-	else:
-		set_process(true)
+	set_process(true)
 
 	calculated_body = shape.get_parent_node_3d()
 	calculated_body.set_meta("collision_damage_calculator", self)

--- a/faster-than-scrap/code/collision_damage_calculator.gd
+++ b/faster-than-scrap/code/collision_damage_calculator.gd
@@ -1,5 +1,8 @@
 extends Node
 
+## All collision damage will be multiplied by this value
+const DAMAGE_MULTIPLIER = 10.0
+
 @export var collision_particles: PackedScene = preload(
 	"res://prefabs/vfx/particles/timed_particles/collision.tscn"
 )
@@ -85,11 +88,10 @@ func calculate_damage(me: Node, oponent: Node) -> Damage:
 		v2 = Vector3(0, 0, 0)
 	else:
 		v2 = oponet_calculator.pre_collision_velocity
-	var base_damage: float = (v1 - v2).dot(direction)
+	var base_damage: float = (v1 - v2).dot(direction) * DAMAGE_MULTIPLIER
 
 	# get multiplies
-	var self_dmg_mult: float = 1
-	self_dmg_mult *= self.self_damage_multiplier
+	var self_dmg_mult = self.self_damage_multiplier
 	if oponet_calculator != null:
 		self_dmg_mult *= oponet_calculator.dealt_damage_multiplier
 

--- a/faster-than-scrap/code/collision_damage_calculator.gd
+++ b/faster-than-scrap/code/collision_damage_calculator.gd
@@ -74,8 +74,6 @@ func _handle_collision(
 
 func _spawn_collision_particles() -> void:
 	var body_direct_state = PhysicsServer3D.body_get_direct_state(calculated_body.get_rid())
-	var contact_count = body_direct_state.get_contact_count()
-
 	var collision_parameters = _calculate_average_collision_values(body_direct_state)
 
 	var average_normal: Vector3 = collision_parameters["average_normal"]

--- a/faster-than-scrap/code/collision_damage_calculator.gd
+++ b/faster-than-scrap/code/collision_damage_calculator.gd
@@ -32,8 +32,9 @@ func _ready() -> void:
 	find_calculated_body()
 
 
-func _on_game_manager_new_game_state(_new_state: GameState.State):
-	find_calculated_body()
+func _on_game_manager_new_game_state(new_state: GameState.State):
+	if new_state == GameState.State.FLY:
+		find_calculated_body()
 
 
 func find_calculated_body():

--- a/faster-than-scrap/code/collision_damage_calculator.gd
+++ b/faster-than-scrap/code/collision_damage_calculator.gd
@@ -68,9 +68,11 @@ func _handle_collision(
 	var damage: Damage = calculate_damage(calculated_body, body)
 	damageable.take_damage(damage, body)
 
-	if collision_particles == null:
-		return
+	if collision_particles != null:
+		_spawn_collision_particles()
 
+
+func _spawn_collision_particles() -> void:
 	var body_direct_state = PhysicsServer3D.body_get_direct_state(calculated_body.get_rid())
 	var contact_count = body_direct_state.get_contact_count()
 

--- a/faster-than-scrap/prefabs/environment/asteroids/single_asteroid/big/big_asteroid1.tscn
+++ b/faster-than-scrap/prefabs/environment/asteroids/single_asteroid/big/big_asteroid1.tscn
@@ -2,14 +2,13 @@
 
 [ext_resource type="Script" uid="uid://chekqae75l00d" path="res://code/evironment/asteroid.gd" id="1_axvgm"]
 [ext_resource type="PackedScene" uid="uid://cj7j6pmi068fm" path="res://art/model_prefabs/asteroids/asteroid_1.tscn" id="2_f1pb0"]
+[ext_resource type="PackedScene" uid="uid://maswxxigwvow" path="res://art/models/asteroids/asteroid_1/asteroid_1_collider.tscn" id="2_s3clk"]
 [ext_resource type="PackedScene" uid="uid://hs3ujnysju5o" path="res://prefabs/collision_damage_calculator.tscn" id="3_wlcj7"]
 [ext_resource type="PackedScene" uid="uid://0txf83d46q4j" path="res://prefabs/modules/functional_components/damage_controller.tscn" id="4_i8vo8"]
 [ext_resource type="PackedScene" uid="uid://c5h05bkp7b8go" path="res://prefabs/ui/poi/asteroid_poi.tscn" id="5_r5hff"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_gro5k"]
 bounce = 1.0
-
-[sub_resource type="SphereShape3D" id="SphereShape3D_keyhs"]
 
 [node name="Asteroid" type="RigidBody3D"]
 axis_lock_linear_y = true
@@ -22,16 +21,15 @@ angular_damp_mode = 1
 script = ExtResource("1_axvgm")
 hp = 1000
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+[node name="asteroid_1_collider" parent="." instance=ExtResource("2_s3clk")]
 transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, 0, 0, 0)
-shape = SubResource("SphereShape3D_keyhs")
 
 [node name="Asteroid1" parent="." instance=ExtResource("2_f1pb0")]
 transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, 0, 0, 0)
 
 [node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("3_wlcj7")]
 damageable = NodePath("../DamageController/Damageable")
-shape = NodePath("../CollisionShape3D")
+shape = NodePath("../asteroid_1_collider")
 
 [node name="DamageController" parent="." instance=ExtResource("4_i8vo8")]
 
@@ -39,9 +37,8 @@ shape = NodePath("../CollisionShape3D")
 collision_layer = 6
 collision_mask = 0
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="DamageController/Damageable" index="0"]
-transform = Transform3D(32, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
-shape = SubResource("SphereShape3D_keyhs")
+[node name="asteroid_1_collider" parent="DamageController/Damageable" index="0" instance=ExtResource("2_s3clk")]
+transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, 0, 0, 0)
 
 [node name="Asteroid Poi" parent="." instance=ExtResource("5_r5hff")]
 transform = Transform3D(32, 0, 0, 0, -1.39876e-06, 32, 0, -32, -1.39876e-06, 0, 0, 0)

--- a/faster-than-scrap/prefabs/environment/asteroids/single_asteroid/big/big_asteroid2.tscn
+++ b/faster-than-scrap/prefabs/environment/asteroids/single_asteroid/big/big_asteroid2.tscn
@@ -21,11 +21,11 @@ angular_damp_mode = 1
 script = ExtResource("1_4mv6f")
 hp = 1000
 
-[node name="Asteroid2" parent="." instance=ExtResource("2_erwgu")]
-transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, 0, 0, 0)
-
 [node name="asteroid_2_collider" parent="." instance=ExtResource("3_ir7qr")]
 transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, -6.304, 0, 10.592)
+
+[node name="Asteroid2" parent="." instance=ExtResource("2_erwgu")]
+transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, 0, 0, 0)
 
 [node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("3_uqly8")]
 damageable = NodePath("../DamageController/Damageable")

--- a/faster-than-scrap/prefabs/environment/asteroids/single_asteroid/big/big_asteroid2.tscn
+++ b/faster-than-scrap/prefabs/environment/asteroids/single_asteroid/big/big_asteroid2.tscn
@@ -2,14 +2,13 @@
 
 [ext_resource type="Script" uid="uid://chekqae75l00d" path="res://code/evironment/asteroid.gd" id="1_4mv6f"]
 [ext_resource type="PackedScene" uid="uid://pxlntfewdl2l" path="res://art/model_prefabs/asteroids/asteroid_2.tscn" id="2_erwgu"]
+[ext_resource type="PackedScene" uid="uid://dlylap8n1812s" path="res://art/models/asteroids/asteroid_2/asteroid_2_collider.tscn" id="3_ir7qr"]
 [ext_resource type="PackedScene" uid="uid://hs3ujnysju5o" path="res://prefabs/collision_damage_calculator.tscn" id="3_uqly8"]
 [ext_resource type="PackedScene" uid="uid://0txf83d46q4j" path="res://prefabs/modules/functional_components/damage_controller.tscn" id="4_or4mp"]
 [ext_resource type="PackedScene" uid="uid://c5h05bkp7b8go" path="res://prefabs/ui/poi/asteroid_poi.tscn" id="5_fkdrx"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_gro5k"]
 bounce = 1.0
-
-[sub_resource type="CapsuleShape3D" id="CapsuleShape3D_nictl"]
 
 [node name="Asteroid" type="RigidBody3D"]
 axis_lock_linear_y = true
@@ -25,13 +24,12 @@ hp = 1000
 [node name="Asteroid2" parent="." instance=ExtResource("2_erwgu")]
 transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, 0, 0, 0)
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
-transform = Transform3D(-1.39876e-06, -31.9255, 2.18206, 32, -1.39551e-06, 9.53809e-08, 0, 2.18206, 31.9255, -3.30312, -1.44384e-07, -1.61414)
-shape = SubResource("CapsuleShape3D_nictl")
+[node name="asteroid_2_collider" parent="." instance=ExtResource("3_ir7qr")]
+transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, -6.304, 0, 10.592)
 
 [node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("3_uqly8")]
 damageable = NodePath("../DamageController/Damageable")
-shape = NodePath("../CollisionShape3D")
+shape = NodePath("../asteroid_2_collider")
 
 [node name="DamageController" parent="." instance=ExtResource("4_or4mp")]
 
@@ -39,9 +37,8 @@ shape = NodePath("../CollisionShape3D")
 collision_layer = 6
 collision_mask = 0
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="DamageController/Damageable" index="0"]
-transform = Transform3D(-1.39876e-06, -31.9255, 2.18206, 32, -1.39551e-06, 9.53809e-08, 0, 2.18206, 31.9255, -3.30312, -1.44384e-07, -1.61414)
-shape = SubResource("CapsuleShape3D_nictl")
+[node name="asteroid_2_collider" parent="DamageController/Damageable" index="0" instance=ExtResource("3_ir7qr")]
+transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, -6.304, 0, 10.592)
 
 [node name="Asteroid Poi" parent="." instance=ExtResource("5_fkdrx")]
 transform = Transform3D(65.0282, 0, 0, 0, 32, 0, 0, 0, 32, -3.30265, 0, 0)

--- a/faster-than-scrap/prefabs/environment/asteroids/single_asteroid/big/big_asteroid3.tscn
+++ b/faster-than-scrap/prefabs/environment/asteroids/single_asteroid/big/big_asteroid3.tscn
@@ -21,11 +21,11 @@ angular_damp_mode = 1
 script = ExtResource("1_vmr2c")
 hp = 1000
 
-[node name="Asteroid3" parent="." instance=ExtResource("2_eb6xg")]
-transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, 0.205451, 0, 0)
-
 [node name="asteroid_3_collider" parent="." instance=ExtResource("3_0hrkk")]
 transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, -10.624, 0, 8)
+
+[node name="Asteroid3" parent="." instance=ExtResource("2_eb6xg")]
+transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, 0.205451, 0, 0)
 
 [node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("3_fh86s")]
 damageable = NodePath("../DamageController/Damageable")

--- a/faster-than-scrap/prefabs/environment/asteroids/single_asteroid/big/big_asteroid3.tscn
+++ b/faster-than-scrap/prefabs/environment/asteroids/single_asteroid/big/big_asteroid3.tscn
@@ -2,15 +2,13 @@
 
 [ext_resource type="Script" uid="uid://chekqae75l00d" path="res://code/evironment/asteroid.gd" id="1_vmr2c"]
 [ext_resource type="PackedScene" uid="uid://1jrjvgq3vqt4" path="res://art/model_prefabs/asteroids/asteroid_3.tscn" id="2_eb6xg"]
+[ext_resource type="PackedScene" uid="uid://cu7xumld3sb0l" path="res://art/models/asteroids/asteroid_3/asteroid_3_collider.tscn" id="3_0hrkk"]
 [ext_resource type="PackedScene" uid="uid://hs3ujnysju5o" path="res://prefabs/collision_damage_calculator.tscn" id="3_fh86s"]
 [ext_resource type="PackedScene" uid="uid://0txf83d46q4j" path="res://prefabs/modules/functional_components/damage_controller.tscn" id="4_go66n"]
 [ext_resource type="PackedScene" uid="uid://c5h05bkp7b8go" path="res://prefabs/ui/poi/asteroid_poi.tscn" id="5_3nkdk"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_gro5k"]
 bounce = 1.0
-
-[sub_resource type="SphereShape3D" id="SphereShape3D_keyhs"]
-radius = 1.005
 
 [node name="Asteroid" type="RigidBody3D"]
 axis_lock_linear_y = true
@@ -26,13 +24,12 @@ hp = 1000
 [node name="Asteroid3" parent="." instance=ExtResource("2_eb6xg")]
 transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, 0.205451, 0, 0)
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
-transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, -7.25742, 0, 0)
-shape = SubResource("SphereShape3D_keyhs")
+[node name="asteroid_3_collider" parent="." instance=ExtResource("3_0hrkk")]
+transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, -10.624, 0, 8)
 
 [node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("3_fh86s")]
 damageable = NodePath("../DamageController/Damageable")
-shape = NodePath("../CollisionShape3D")
+shape = NodePath("../asteroid_3_collider")
 
 [node name="DamageController" parent="." instance=ExtResource("4_go66n")]
 
@@ -40,9 +37,8 @@ shape = NodePath("../CollisionShape3D")
 collision_layer = 6
 collision_mask = 0
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="DamageController/Damageable" index="0"]
-transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, -7.257, 0, 0)
-shape = SubResource("SphereShape3D_keyhs")
+[node name="asteroid_3_collider" parent="DamageController/Damageable" index="0" instance=ExtResource("3_0hrkk")]
+transform = Transform3D(32, 0, 0, 0, 32, 0, 0, 0, 32, -10.624, 0, 8)
 
 [node name="Asteroid Poi" parent="." instance=ExtResource("5_3nkdk")]
 transform = Transform3D(56.542, 0, 0, 0, -2.47153e-06, 56.542, 0, -56.542, -2.47153e-06, -6.64216, 0, 2.1887)

--- a/faster-than-scrap/prefabs/environment/asteroids/single_asteroid/small/asteroid2.tscn
+++ b/faster-than-scrap/prefabs/environment/asteroids/single_asteroid/small/asteroid2.tscn
@@ -8,7 +8,9 @@
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_gro5k"]
 bounce = 1.0
 
-[sub_resource type="SphereShape3D" id="SphereShape3D_keyhs"]
+[sub_resource type="CapsuleShape3D" id="CapsuleShape3D_0351a"]
+radius = 0.447987
+height = 2.12803
 
 [node name="Asteroid" type="RigidBody3D"]
 axis_lock_linear_y = true
@@ -20,10 +22,11 @@ angular_damp_mode = 1
 script = ExtResource("1_n8w1b")
 hp = 5
 
-[node name="Asteroid2" parent="." instance=ExtResource("2_n8w1b")]
-
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
-shape = SubResource("SphereShape3D_keyhs")
+transform = Transform3D(-0.0279217, -0.995694, 0.0883904, 0.99961, -0.0278123, 0.00246897, 0, 0.0884249, 0.996083, -0.0923008, 0.0316356, -0.0343292)
+shape = SubResource("CapsuleShape3D_0351a")
+
+[node name="Asteroid2" parent="." instance=ExtResource("2_n8w1b")]
 
 [node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("3_lg46a")]
 damageable = NodePath("../DamageController/Damageable")
@@ -36,7 +39,8 @@ collision_layer = 6
 collision_mask = 0
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="DamageController/Damageable" index="0"]
-shape = SubResource("SphereShape3D_keyhs")
+transform = Transform3D(-0.0279217, -0.995694, 0.0883904, 0.99961, -0.0278123, 0.00246897, 0, 0.0884249, 0.996083, -0.0923008, 0.0316356, -0.0343292)
+shape = SubResource("CapsuleShape3D_0351a")
 
 [connection signal="damaged" from="DamageController" to="." method="take_damage"]
 

--- a/faster-than-scrap/prefabs/environment/asteroids/single_asteroid/small/asteroid3.tscn
+++ b/faster-than-scrap/prefabs/environment/asteroids/single_asteroid/small/asteroid3.tscn
@@ -9,7 +9,7 @@
 bounce = 1.0
 
 [sub_resource type="SphereShape3D" id="SphereShape3D_keyhs"]
-radius = 1.005
+radius = 0.930651
 
 [node name="Asteroid" type="RigidBody3D"]
 axis_lock_linear_y = true
@@ -21,11 +21,12 @@ angular_damp_mode = 1
 script = ExtResource("1_ub458")
 hp = 5
 
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.0262855, 0.133777)
+shape = SubResource("SphereShape3D_keyhs")
+
 [node name="Asteroid3" parent="." instance=ExtResource("2_ub458")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.205451, 0, 0)
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
-shape = SubResource("SphereShape3D_keyhs")
 
 [node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("3_hlgqs")]
 damageable = NodePath("../DamageController/Damageable")
@@ -38,6 +39,7 @@ collision_layer = 6
 collision_mask = 0
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="DamageController/Damageable" index="0"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.026, 0.134)
 shape = SubResource("SphereShape3D_keyhs")
 
 [connection signal="damaged" from="DamageController" to="." method="take_damage"]

--- a/faster-than-scrap/prefabs/modules/battery.tscn
+++ b/faster-than-scrap/prefabs/modules/battery.tscn
@@ -82,7 +82,6 @@ shape = SubResource("SphereShape3D_e1j53")
 [node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("5_mgd80")]
 damageable = NodePath("../DamageController2/Damageable")
 shape = NodePath("..")
-self_damage_multiplier = 5.0
 
 [connection signal="damaged" from="DamageController2" to="." method="take_damage"]
 

--- a/faster-than-scrap/prefabs/modules/frame1.tscn
+++ b/faster-than-scrap/prefabs/modules/frame1.tscn
@@ -54,7 +54,6 @@ shape = SubResource("SphereShape3D_e1j53")
 [node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("4_jnq3k")]
 damageable = NodePath("../DamageController2/Damageable")
 shape = NodePath("..")
-self_damage_multiplier = 5.0
 
 [connection signal="damaged" from="DamageController2" to="." method="take_damage"]
 

--- a/faster-than-scrap/prefabs/modules/frame2.tscn
+++ b/faster-than-scrap/prefabs/modules/frame2.tscn
@@ -54,7 +54,6 @@ shape = SubResource("SphereShape3D_e1j53")
 [node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("5_v7s2g")]
 damageable = NodePath("../DamageController2/Damageable")
 shape = NodePath("..")
-self_damage_multiplier = 5.0
 
 [connection signal="damaged" from="DamageController2" to="." method="take_damage"]
 

--- a/faster-than-scrap/prefabs/modules/thruster.tscn
+++ b/faster-than-scrap/prefabs/modules/thruster.tscn
@@ -57,7 +57,6 @@ shape = SubResource("BoxShape3D_lwypn")
 [node name="CollisionDamageCalculator" parent="." node_paths=PackedStringArray("damageable", "shape") instance=ExtResource("6_24upk")]
 damageable = NodePath("../DamageController/Damageable")
 shape = NodePath("..")
-self_damage_multiplier = 10.0
 
 [node name="ModuleDisplay" parent="." instance=ExtResource("4_putpi")]
 


### PR DESCRIPTION
- Used mesh colliders for big asteroids
    - Caution: Godot complains that mesh colliders with nonstatic rigidbodies may behave incorrectly, but in my (very extensive) tests, they worked fine, so I think it should be ok?
- Reordered colliders in big and small asteroids to be the first child of rigidbody
    - For some reason (not sure if that's a Godot thing or our spaghetti) the collisions were ignored if they were not the first child
- Adjusted colliders in small asteroids to better fit their visuals
- Unified self_damage_multiplier to be equal to 1 in all modules
    - This will probably need to be further balanced in the future, but currently the values were very extreme (e.g. thrusters taking 10x more collision damage than weapons). The balancing should be easier with everything set to 1, as a starting point
- Added constant *10 collision damage multiplier
    - This is intended to replace the (now reset) per-module multipliers. Also solves the issue with asteroid collisions not doing much damage at all, that was raised during feedback gathering
- Fixed an awful terrible bug with collisions not working for modules bought in the shop
- Fixed bug with access to previously freed instances that happened sometimes during collisions, after a module was destroyed
- Fixed collision damage sometimes being negative
    - Also the collision damage calculations are now better for elongated, non-round objects. Still not perfect though, because they don't take the objects' rotation into account, but that would require a huge rework and a *lot* of maths (especially since `PhysicsDirectBodyState3D.get_contact_impulse()` [is broken in Godot since 2023](https://github.com/godotengine/godot/issues/73541) lol) (the PR to fix this [also seems to have been waiting since 2023](https://github.com/godotengine/godot/pull/73569))

---

Some collision bugs are still present:
- Enemies act as immovable brick walls and don't take any collision damage
    - Fixing this will most probably require rewriting them to be rigidbodies. I don't know how the enemies work, so I'd prefer someone more knowledgable to look into this
- Detached modules don't take collision damage
    - The collision damage calculator is a big plate of spaghetti and fixing this would require a lot of work, to notify it somehow when it's module gets detached. The detached modules still *deal* collision damage to the player, so I'd say it's not worth the time and should not be noticeable in any way.