### PR TITLE
Better particle performance

### DIFF
--- a/faster-than-scrap/prefabs/vfx/particles/base_projectile_hit_particles.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/base_projectile_hit_particles.tscn
@@ -32,6 +32,7 @@ height = 0.4
 
 [node name="Explosion" type="GPUParticles3D"]
 material_override = SubResource("StandardMaterial3D_o3xl1")
+cast_shadow = 0
 amount = 128
 lifetime = 3.0
 one_shot = true

--- a/faster-than-scrap/prefabs/vfx/particles/basic/big_explosion_particle.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/basic/big_explosion_particle.tscn
@@ -37,6 +37,7 @@ alpha_curve = SubResource("CurveTexture_8whst")
 
 [node name="BigExplosionParticle" type="GPUParticles3D"]
 material_override = ExtResource("1_m2k8q")
+cast_shadow = 0
 emitting = false
 amount = 10
 lifetime = 3.0

--- a/faster-than-scrap/prefabs/vfx/particles/basic/directional_sparks.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/basic/directional_sparks.tscn
@@ -36,6 +36,7 @@ bottom_radius = 0.25
 
 [node name="DirectionalSparks" type="GPUParticles3D"]
 material_override = SubResource("StandardMaterial3D_o6jcs")
+cast_shadow = 0
 emitting = false
 amount = 10
 lifetime = 0.2

--- a/faster-than-scrap/prefabs/vfx/particles/basic/fire.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/basic/fire.tscn
@@ -5,6 +5,7 @@
 
 [node name="exhaust fire2" type="CSGCylinder3D"]
 transform = Transform3D(-6.61657e-11, -4.36557e-08, -1, -1, -4.37722e-08, 3.18323e-12, -4.4005e-08, 1, -4.3714e-08, 0, 0, 0)
+cast_shadow = 0
 radius = 0.25
 smooth_faces = false
 material = ExtResource("1_tjqjc")

--- a/faster-than-scrap/prefabs/vfx/particles/basic/ring.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/basic/ring.tscn
@@ -27,6 +27,7 @@ color_ramp = SubResource("GradientTexture1D_308ir")
 
 [node name="Ring" type="GPUParticles3D"]
 material_override = ExtResource("1_14nmt")
+cast_shadow = 0
 emitting = false
 amount = 1
 one_shot = true

--- a/faster-than-scrap/prefabs/vfx/particles/basic/shiny_particles.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/basic/shiny_particles.tscn
@@ -22,6 +22,7 @@ material = ExtResource("1_q6rdy")
 
 [node name="Shiny" type="GPUParticles3D"]
 transform = Transform3D(0.999976, 0.0037943, -0.00586796, -0.00380285, 0.999992, -0.00144701, 0.00586243, 0.00146926, 0.999982, 0, 0, 0)
+cast_shadow = 0
 amount = 30
 lifetime = 10.0
 process_material = SubResource("ParticleProcessMaterial_pl0tl")

--- a/faster-than-scrap/prefabs/vfx/particles/basic/small_explosion_particle.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/basic/small_explosion_particle.tscn
@@ -38,6 +38,7 @@ alpha_curve = SubResource("CurveTexture_8whst")
 
 [node name="ExplosionParticle" type="GPUParticles3D"]
 material_override = ExtResource("1_6c153")
+cast_shadow = 0
 amount = 10
 lifetime = 3.0
 one_shot = true

--- a/faster-than-scrap/prefabs/vfx/particles/basic/sparks.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/basic/sparks.tscn
@@ -37,6 +37,7 @@ bottom_radius = 0.25
 
 [node name="Sparks" type="GPUParticles3D"]
 material_override = SubResource("StandardMaterial3D_o6jcs")
+cast_shadow = 0
 lifetime = 0.1
 trail_lifetime = 0.01
 process_material = SubResource("ParticleProcessMaterial_o6jcs")

--- a/faster-than-scrap/prefabs/vfx/particles/basic/thruster_fire.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/basic/thruster_fire.tscn
@@ -37,6 +37,7 @@ color_ramp = SubResource("GradientTexture1D_tjqjc")
 
 [node name="Fire" type="GPUParticles3D"]
 material_override = SubResource("StandardMaterial3D_767bt")
+cast_shadow = 0
 amount = 200
 lifetime = 0.25
 local_coords = true

--- a/faster-than-scrap/prefabs/vfx/particles/beam_particles.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/beam_particles.tscn
@@ -31,6 +31,7 @@ height = 0.4
 
 [node name="BeamParticles" type="GPUParticles3D"]
 material_override = SubResource("StandardMaterial3D_o3xl1")
+cast_shadow = 0
 amount = 64
 speed_scale = 2.0
 process_material = SubResource("ParticleProcessMaterial_fg0bf")

--- a/faster-than-scrap/prefabs/vfx/particles/dust_particles.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/dust_particles.tscn
@@ -55,6 +55,7 @@ script = ExtResource("1_6gb75")
 
 [node name="DustTrails" type="GPUParticles3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -7, 0)
+cast_shadow = 0
 amount = 100
 lifetime = 4.0
 process_material = SubResource("ParticleProcessMaterial_klrfn")

--- a/faster-than-scrap/prefabs/vfx/particles/falling_dust_particles.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/falling_dust_particles.tscn
@@ -59,6 +59,7 @@ script = ExtResource("1_rera4")
 
 [node name="DustTrails" type="GPUParticles3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
+cast_shadow = 0
 amount = 50
 lifetime = 4.0
 trail_enabled = true

--- a/faster-than-scrap/prefabs/vfx/particles/laser_muzzle.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/laser_muzzle.tscn
@@ -40,6 +40,7 @@ size = 0.05
 curve = SubResource("Curve_a44b7")
 
 [node name="Laser_Muzzle" type="GPUParticles3D"]
+cast_shadow = 0
 emitting = false
 amount = 200
 lifetime = 0.4

--- a/faster-than-scrap/prefabs/vfx/particles/muzzle_flash.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/muzzle_flash.tscn
@@ -44,6 +44,7 @@ size = 0.1
 curve = SubResource("Curve_pg335")
 
 [node name="MuzzleFlash" type="GPUParticles3D"]
+cast_shadow = 0
 emitting = false
 amount = 100
 lifetime = 0.15

--- a/faster-than-scrap/prefabs/vfx/particles/pseudoTrail.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/pseudoTrail.tscn
@@ -33,6 +33,7 @@ alpha_curve = SubResource("CurveTexture_8c3mm")
 [node name="Trail" type="GPUParticles3D"]
 transform = Transform3D(1, 3.85398e-11, 5.82077e-11, -2.33058e-11, 1, 0, -5.82077e-11, -2.32831e-10, 1, 0, 0, 0)
 material_override = SubResource("StandardMaterial3D_nnrsk")
+cast_shadow = 0
 amount = 10
 lifetime = 0.1
 transform_align = 3

--- a/faster-than-scrap/prefabs/vfx/particles/satelite_signal.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/satelite_signal.tscn
@@ -40,6 +40,7 @@ vertex_color_use_as_albedo = true
 material = SubResource("StandardMaterial3D_65fdt")
 
 [node name="SateliteSignal" type="GPUParticles3D"]
+cast_shadow = 0
 amount = 3
 lifetime = 5.0
 local_coords = true

--- a/faster-than-scrap/prefabs/vfx/particles/timed_particles/directional_sparks.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/timed_particles/directional_sparks.tscn
@@ -37,6 +37,7 @@ bottom_radius = 0.25
 
 [node name="DirectionalSparks" type="GPUParticles3D"]
 material_override = SubResource("StandardMaterial3D_o6jcs")
+cast_shadow = 0
 emitting = false
 amount = 10
 lifetime = 0.2

--- a/faster-than-scrap/prefabs/vfx/particles/timed_particles/explosion.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/timed_particles/explosion.tscn
@@ -30,6 +30,7 @@ color_ramp = SubResource("GradientTexture1D_h5qc5")
 
 [node name="Explosion" type="GPUParticles3D"]
 material_override = SubResource("StandardMaterial3D_o3xl1")
+cast_shadow = 0
 process_material = SubResource("ParticleProcessMaterial_tsekn")
 draw_pass_1 = SubResource("SphereMesh_fht6s")
 script = ExtResource("1_r6oit")


### PR DESCRIPTION
Disabled shadows for each particle system. Turning them off makes visual changes in performance.

Shadows on: 
- time per frame: 192ms and even 220ms
Shadows off: 
- time per frame: 148ms  <- better

Time measured on level show below, with all 4 groups of drones attacking the player.

Try comparing if this works smoother:
![image](https://github.com/user-attachments/assets/a4eaee15-a2d1-48cd-8e4e-c48a2362e5b8)
