### PR TITLE
Update ship modules list on attach/detach

### DIFF
--- a/faster-than-scrap/code/player/player_ship.gd
+++ b/faster-than-scrap/code/player/player_ship.gd
@@ -19,7 +19,7 @@ signal fuel_change(new_value: int)
 
 ## All modules of the ship (to prevent checking the tree hierarchy).
 ## Mostly used for building phase
-@export var modules: Array[Module] = []
+var modules: Array[Module] = []
 var money: int = 0
 var current_fuel: int = 0:
 	get:
@@ -71,6 +71,8 @@ func _center_of_mass() -> Vector3:
 		center += mod.position
 	center /= GameManager.player_ship.modules.size()
 	return center
+
+
 func _physics_process(_delta: float) -> void:
 	if not DebugMenu.enable_debug_movement:
 		return

--- a/faster-than-scrap/code/ship/modules/module.gd
+++ b/faster-than-scrap/code/ship/modules/module.gd
@@ -175,12 +175,12 @@ func detach_all_children(explosion_center: Vector3) -> void:
 
 ## Called when the module is attached to the ship
 func on_attach() -> void:
-	pass
+	GameManager.player_ship.modules.append(self)
 
 
 ## Called just before the module is detached from the ship
 func on_detach() -> void:
-	pass
+	GameManager.player_ship.modules.erase(self)
 
 
 ## Called when the module is attached to a different part of the ship than it previously was

--- a/faster-than-scrap/code/ship/modules/module.gd
+++ b/faster-than-scrap/code/ship/modules/module.gd
@@ -175,12 +175,12 @@ func detach_all_children(explosion_center: Vector3) -> void:
 
 ## Called when the module is attached to the ship
 func on_attach() -> void:
-	GameManager.player_ship.modules.append(self)
+	pass
 
 
 ## Called just before the module is detached from the ship
 func on_detach() -> void:
-	GameManager.player_ship.modules.erase(self)
+	pass
 
 
 ## Called when the module is attached to a different part of the ship than it previously was

--- a/faster-than-scrap/code/ship/modules/module.gd
+++ b/faster-than-scrap/code/ship/modules/module.gd
@@ -128,7 +128,6 @@ func show_on_module_camera() -> void:
 
 ## Destroy self and detach children
 func _on_destroy() -> void:
-	GameManager.player_ship.modules.erase(self)
 	if parent_module != null:
 		parent_module.child_modules.erase(self)
 	_explode()
@@ -180,7 +179,7 @@ func on_attach() -> void:
 
 ## Called just before the module is detached from the ship
 func on_detach() -> void:
-	pass
+	GameManager.player_ship.modules.erase(self)
 
 
 ## Called when the module is attached to a different part of the ship than it previously was

--- a/faster-than-scrap/prefabs/ships/flyable_ship_tutorial.tscn
+++ b/faster-than-scrap/prefabs/ships/flyable_ship_tutorial.tscn
@@ -8,7 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://taxlqo87sp7s" path="res://prefabs/modules/thruster.tscn" id="4_vxcau"]
 [ext_resource type="PackedScene" uid="uid://cujiw86wtjlp8" path="res://prefabs/modules/frame1.tscn" id="6_bq2yq"]
 
-[node name="FlyableShip" type="RigidBody3D" node_paths=PackedStringArray("cockpit", "modules", "leave_animation")]
+[node name="FlyableShip" type="RigidBody3D" node_paths=PackedStringArray("cockpit", "leave_animation")]
 axis_lock_linear_y = true
 axis_lock_angular_x = true
 axis_lock_angular_z = true
@@ -17,7 +17,6 @@ linear_damp_mode = 1
 angular_damp_mode = 1
 script = ExtResource("1_y502x")
 cockpit = NodePath("Cockpit")
-modules = [NodePath("Cockpit"), NodePath("Thruster Backward"), NodePath("Thruster Right"), NodePath("Thruster Left"), NodePath("Thruster Forward"), NodePath("Frame Center"), NodePath("Frame Center2"), NodePath("Frame Center3"), NodePath("Frame Left Inner"), NodePath("Frame Left Outer"), NodePath("Frame Right Inner"), NodePath("Frame Right Outer"), NodePath("Laser Right"), NodePath("Laser Left")]
 team = 0
 leave_animation = NodePath("Cockpit/AnimationPlayer")
 


### PR DESCRIPTION
Tutorial ship has two reference for some modules (one assigned in insepctor, second in ready).
Removed export, so the array is empty at start.

Moreover those references were not properly removed when module had children (only the destroyed module was removed) - also fixed. Now hud doesn't dissapear when some modules are destroyed