### PR TITLE
Fix enemies shooting the player ship when it's moving down through a portal

### DIFF
--- a/faster-than-scrap/code/enemy/states/move/change_position.gd
+++ b/faster-than-scrap/code/enemy/states/move/change_position.gd
@@ -17,10 +17,12 @@ var direction: Vector3
 func enter(_previous_state_path: String, _data := {}) -> void:
 	counter = 0
 	start_pos = ship_controller.global_position
+	start_pos.y = 0
 	var copied_points = points.duplicate()
 	copied_points.erase(target_node)  # actual position
 	target_node = copied_points.pick_random()  # select new position
 	direction = target_node.global_position - start_pos
+	direction.y = 0
 	direction /= duration
 
 

--- a/faster-than-scrap/code/enemy/states/move/move_to_orbit_place.gd
+++ b/faster-than-scrap/code/enemy/states/move/move_to_orbit_place.gd
@@ -19,18 +19,23 @@ var destination: Vector3
 func enter(_previous_state_path: String, _data := {}) -> void:
 	target = GameManager.find_closest_ship(ship_controller.ship)
 	var direction_from_target = (
-		(self.ship_controller.ship.global_position - self.target.global_position).normalized()
+		self.ship_controller.ship.global_position - self.target.global_position
 	)
+	direction_from_target.y = 0
+	direction_from_target = direction_from_target.normalized()
+
 	var rng = RandomNumberGenerator.new()
 	var rotation = deg_to_rad(rng.randf_range(-max_angle_diff, max_angle_diff))
 	direction_from_target = direction_from_target.rotated(Vector3.UP, rotation)
 
 	destination = self.target.global_position + direction_from_target * orbit_radius
+	destination.y = 0
 
 
 ## Called by the state machine on the engine's main loop tick.
 func state_physics_update(_delta: float) -> void:
 	var direction = destination - self.ship_controller.ship.global_position
+	direction.y = 0
 
 	ship_controller.velocity = direction * lerp_strength
 	ship_controller.move_and_slide()

--- a/faster-than-scrap/code/enemy/states/move/orbit.gd
+++ b/faster-than-scrap/code/enemy/states/move/orbit.gd
@@ -11,6 +11,7 @@ var orbit_radial_speed: float
 func enter(_previous_state_path: String, _data := {}) -> void:
 	target = GameManager.find_closest_ship(ship_controller.ship)
 	direction_from_target = self.ship_controller.ship.global_position - self.target.global_position
+	direction_from_target.y = 0
 	orbit_radial_speed = deg_to_rad(orbit_angular_speed)
 
 
@@ -22,7 +23,10 @@ func state_physics_update(delta: float) -> void:
 
 	# calculate direct pos
 	var direct_pos = self.target.global_position + direction_from_target * orbit_radius
+	direct_pos.y = 0
 
 	var direction = direct_pos - self.ship_controller.ship.global_position
+	direction.y = 0
+
 	ship_controller.velocity = direction * lerp_strength
 	ship_controller.move_and_slide()

--- a/faster-than-scrap/code/enemy/states/move/state_npc_movemenet/movement_state.gd
+++ b/faster-than-scrap/code/enemy/states/move/state_npc_movemenet/movement_state.gd
@@ -1,13 +1,14 @@
 class_name movementState extends StateNPC
 
 ## width of band around circle defined by target and min_range_to_target
-@export var dead_zone: float = 2;
+@export var dead_zone: float = 2
 ## in dead_zone do we stop in place [false] or keep circling [true]
 @export var circle_target: bool = false
 
 ## we will check for new target every X ms
 @export var recheck_time: float = 5
-var _recheck_timer: float = 999999;
+var _recheck_timer: float = 999999
+
 
 func check_target(_delta: float):
 	_recheck_timer += _delta
@@ -22,6 +23,7 @@ func move_target_spotted(min_range_to_target: int) -> void:
 		check_target(INF)
 		return
 	var vector_to_target = target.global_position - ship_controller.global_position
+	vector_to_target.y = 0
 	var direction = vector_to_target.normalized()
 	var target_basis: Basis
 
@@ -34,14 +36,18 @@ func move_target_spotted(min_range_to_target: int) -> void:
 		target_basis = Basis.looking_at(-1 * direction)
 
 	# if we are outside of dead zone proceed normally - rotate and move
-	if abs(vector_to_target.length() - min_range_to_target) > dead_zone/2:
-		ship_controller.basis = ship_controller.basis.slerp(target_basis, ship_controller.rotation_speed)
+	if abs(vector_to_target.length() - min_range_to_target) > dead_zone / 2:
+		ship_controller.basis = ship_controller.basis.slerp(
+			target_basis, ship_controller.rotation_speed
+		)
 		ship_controller.velocity = ship_controller.speed * ship_controller.basis.z * -1
 	# if we are in dead zone and not circling, then stop moving, and rotate towards target
 	elif !circle_target:
 		ship_controller.velocity = ship_controller.velocity.lerp(Vector3.ZERO, 0.04)
 		target_basis = Basis.looking_at(direction)
-		ship_controller.basis = ship_controller.basis.slerp(target_basis, ship_controller.rotation_speed)
+		ship_controller.basis = ship_controller.basis.slerp(
+			target_basis, ship_controller.rotation_speed
+		)
 	# if are in dead zone and circling, then move forward, but do not rotate
 	# we will leave the dead zone, return to it and again move in a line
 	# not bad illusion of flying in a circle around target

--- a/faster-than-scrap/code/enemy/states/move/teleport.gd
+++ b/faster-than-scrap/code/enemy/states/move/teleport.gd
@@ -21,13 +21,17 @@ var time_accumulator: float
 func enter(_previous_state_path: String, _data := {}) -> void:
 	target = GameManager.find_closest_ship(ship_controller.ship)
 	var direction_from_target = (
-		(self.ship_controller.ship.global_position - self.target.global_position).normalized()
+		self.ship_controller.ship.global_position - self.target.global_position
 	)
+	direction_from_target.y = 0
+	direction_from_target = direction_from_target.normalized()
+
 	var rng = RandomNumberGenerator.new()
 	var rotation = deg_to_rad(rng.randf_range(-max_angle_diff, max_angle_diff))
 	direction_from_target = direction_from_target.rotated(Vector3.UP, rotation)
 
 	destination = self.target.global_position + direction_from_target * teleport_radius
+	destination.y = 0
 	time_accumulator = 0
 
 	# shrink

--- a/faster-than-scrap/code/enemy/states/rotate/look_at_target.gd
+++ b/faster-than-scrap/code/enemy/states/rotate/look_at_target.gd
@@ -11,6 +11,7 @@ func enter(_previous_state_path: String, _data := {}) -> void:
 func state_physics_update(_delta: float) -> void:
 	# calculat target rotation
 	var look_direction = self.target.global_position - self.ship_controller.global_position
+	look_direction.y = 0
 	var rotation = ship_controller.rotation
 
 	ship_controller.rotation.y = lerp_angle(

--- a/faster-than-scrap/code/enemy/states/rotate/look_at_target_with_object.gd
+++ b/faster-than-scrap/code/enemy/states/rotate/look_at_target_with_object.gd
@@ -19,6 +19,7 @@ func state_physics_update(_delta: float) -> void:
 
 	# calculate target rotation
 	var look_direction = self.target.global_position - self.ship_controller.global_position
+	look_direction.y = 0
 	var rotation = ship_controller.rotation  # already global
 
 	var target_rot = atan2(-look_direction.x, -look_direction.z) + rotation_offset
@@ -36,6 +37,7 @@ func _select_look_object() -> void:
 			objects.remove_at(index)
 		# check angle between forward and direction to target
 		var direction_to_target = self.target.global_position - object.global_position
+		direction_to_target.y = 0
 		var forward = -object.global_transform.basis.z  # in godot forward is [0,0,-1]
 		var angle = direction_to_target.angle_to(forward)
 

--- a/faster-than-scrap/code/enemy/states/rotate/rotate.gd
+++ b/faster-than-scrap/code/enemy/states/rotate/rotate.gd
@@ -6,22 +6,25 @@ extends StateNPC
 
 var start_rot: Quaternion
 var final_rot: Quaternion
-var time : float = 0
+var time: float = 0
+
 
 func enter(_previous_state_path: String, _data := {}) -> void:
 	time = 0
 	start_rot = ship_controller.basis.get_rotation_quaternion()
-	var diff := Quaternion.from_euler(Vector3(0, deg_to_rad(y_rotation),0))
+	var diff := Quaternion.from_euler(Vector3(0, deg_to_rad(y_rotation), 0))
 	final_rot = start_rot * diff
+
 
 ## Called by the state machine on the engine's main loop tick.
 func state_update(delta: float) -> void:
 	time += delta
-	var percentage := time/duration
+	var percentage := time / duration
 	if percentage >= 1.0:
 		ship_controller.rotation = final_rot.get_euler()
 	else:
-		ship_controller.rotation += Vector3(0, deg_to_rad(y_rotation),0) * delta / duration
+		ship_controller.rotation += Vector3(0, deg_to_rad(y_rotation), 0) * delta / duration
+
 
 func exit() -> void:
 	ship_controller.rotation = final_rot.get_euler()

--- a/faster-than-scrap/code/enemy/transitions/inRange.gd
+++ b/faster-than-scrap/code/enemy/transitions/inRange.gd
@@ -2,11 +2,13 @@ extends baseTransition
 
 @export var range_treshold := 30
 
+
 func condition() -> void:
 	target = GameManager.find_closest_ship(ship_controller.ship)
 	# code for no ship found
 	if target == ship_controller.ship:
 		return
 	var vector_to_target = target.global_position - ship_controller.global_position
+	vector_to_target.y = 0
 	if vector_to_target.length() < range_treshold:
 		finished.emit(new_state.name)

--- a/faster-than-scrap/code/enemy/transitions/outOfRange.gd
+++ b/faster-than-scrap/code/enemy/transitions/outOfRange.gd
@@ -9,5 +9,6 @@ func condition() -> void:
 	if target == ship_controller.ship:
 		return
 	var vector_to_target = target.global_position - ship_controller.ship.global_position
+	vector_to_target.y = 0
 	if vector_to_target.length() > range_treshold:
 		finished.emit(new_state.name)


### PR DESCRIPTION
When the player ship was playing the jump animation and moving to the next level, the enemies were able to rotate downwards towards it and shoot it anyways. This is fixed by setting vector.y to 0 in all enemy states that deal with player position. Some of the changes might be unnecessary, but since we never want to include the Y height in our calculations, this shouldn't break anything