### PR TITLE
Fix weird collision bug

### DIFF
--- a/faster-than-scrap/code/collision_damage_calculator.gd
+++ b/faster-than-scrap/code/collision_damage_calculator.gd
@@ -75,6 +75,9 @@ func _handle_collision(
 
 func _spawn_collision_particles() -> void:
 	var body_direct_state = PhysicsServer3D.body_get_direct_state(calculated_body.get_rid())
+	if body_direct_state == null:
+		return
+
 	var collision_parameters = _calculate_average_collision_values(body_direct_state)
 
 	var average_normal: Vector3 = collision_parameters["average_normal"]
@@ -110,6 +113,9 @@ func calculate_damage(me: Node, oponent: Node) -> Damage:
 
 	# calculate base damage
 	var body_direct_state = PhysicsServer3D.body_get_direct_state(calculated_body.get_rid())
+	if body_direct_state == null:
+		return Damage.new(0, Damage.Type.COLLISION)
+
 	var collision_parameters = _calculate_average_collision_values(body_direct_state)
 
 	var direction: Vector3 = -collision_parameters["average_normal"]


### PR DESCRIPTION
I don't know why or how it was happening, but sometimes (extremely rarely, like once every few hours), the collision damage calculator would throw errors related to body_direct_state being null. I *think* the bug is somehow related to collisions occurring when changing scenes, but I wasn't able to replicate it. These changes should fix this bug (although I cannot confirm this 100% as I can't reliably replicate it)