### PR TITLE
Better thrusters

### DIFF
--- a/faster-than-scrap/code/evironment/asteroid.gd
+++ b/faster-than-scrap/code/evironment/asteroid.gd
@@ -2,7 +2,7 @@ class_name Asteroid
 extends RigidBody3D
 
 @export_category("Stats")
-@export var hp: int = 100
+@export var hp: float = 100
 @export_group("StartValues")
 # parameters of start rotation speed, to prevent being static and dull
 @export var start_speed_range: float = 1

--- a/faster-than-scrap/prefabs/modules/thruster.tscn
+++ b/faster-than-scrap/prefabs/modules/thruster.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://taxlqo87sp7s"]
+[gd_scene load_steps=14 format=3 uid="uid://taxlqo87sp7s"]
 
 [ext_resource type="Script" uid="uid://6f2yjn6wgcun" path="res://code/ship/modules/weapons/weapon_module.gd" id="1_18ma3"]
 [ext_resource type="Script" uid="uid://crmxerc164n6q" path="res://code/weapons/constant_fire_weapon.gd" id="2_5rd74"]
@@ -9,10 +9,14 @@
 [ext_resource type="PackedScene" uid="uid://hs3ujnysju5o" path="res://prefabs/collision_damage_calculator.tscn" id="6_24upk"]
 [ext_resource type="AudioStream" uid="uid://dndqigfvfh227" path="res://art/audio/sounds/thruster.mp3" id="8_gyi6c"]
 [ext_resource type="Script" uid="uid://b1ghhc3fukfu3" path="res://code/sound/sound_emitter.gd" id="11_de7ep"]
+[ext_resource type="PackedScene" uid="uid://cyw1yf0fdjx1j" path="res://prefabs/modules/functional_components/illegal_placement_zone.tscn" id="11_xhd0w"]
 [ext_resource type="PackedScene" uid="uid://bij3qdd0iavi3" path="res://prefabs/modules/functional_components/direction_arrow.tscn" id="12_sy3m8"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_lwypn"]
-size = Vector3(0.783203, 0.935, 1.76978)
+size = Vector3(0.742188, 0.698242, 1.76196)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_sy3m8"]
+size = Vector3(0.756836, 0.728271, 0.747574)
 
 [node name="Thruster" type="CollisionShape3D" node_paths=PackedStringArray("weapon", "attach_points", "sprite", "label")]
 shape = SubResource("BoxShape3D_lwypn")
@@ -29,25 +33,25 @@ prize = 2
 description = "Basic movement module. Activate to push ship forward (relative to thruster)."
 
 [node name="ConstantFireWeapon" type="Node3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -1.26313)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.898123)
 script = ExtResource("2_5rd74")
 energy_cost = 10.0
 recoil_force = 400.0
 projectile = ExtResource("3_24upk")
 
 [node name="ThrusterModel" parent="." instance=ExtResource("2_br7jh")]
-transform = Transform3D(-3.67176e-08, 0, -0.84, 0, 0.84, 0, 0.84, 0, -3.67176e-08, 0, 0, 0.145)
+transform = Transform3D(-3.67176e-08, 0, -0.84, 0, 0.84, 0, 0.84, 0, -3.67176e-08, -2.70104e-09, 0, 0.206793)
 
 [node name="AttachPoints" type="Node3D" parent="."]
 
 [node name="AttachPoint" type="Node3D" parent="AttachPoints"]
-transform = Transform3D(-1, 0, 8.74228e-08, 0, 1, 0, -8.74228e-08, 0, -1, 4.15564e-09, 0, 0.938169)
+transform = Transform3D(-1, 0, 8.74228e-08, 0, 1, 0, -8.74228e-08, 0, -1, 8.86382e-09, 0, 0.884314)
 
 [node name="AttachPoint2" type="Node3D" parent="AttachPoints"]
-transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 0.424305, 0, -5.93143e-09)
+transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 0.373358, 0, 0.199009)
 
 [node name="AttachPoint3" type="Node3D" parent="AttachPoints"]
-transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, -0.424, 0, 0)
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, -0.373, 0, 0.199)
 
 [node name="DamageController" parent="." instance=ExtResource("5_24upk")]
 
@@ -73,6 +77,12 @@ max_random_start_offset = 10.0
 metadata/_custom_type_script = "uid://b1ghhc3fukfu3"
 
 [node name="DirectionArrow" parent="." instance=ExtResource("12_sy3m8")]
+
+[node name="Illegal Placement Zone" parent="." instance=ExtResource("11_xhd0w")]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Illegal Placement Zone"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.522053)
+shape = SubResource("BoxShape3D_sy3m8")
 
 [connection signal="activated" from="." to="SoundEmitter" method="start_playing"]
 [connection signal="deactivated" from="." to="SoundEmitter" method="stop_playing"]

--- a/faster-than-scrap/prefabs/modules/thruster.tscn
+++ b/faster-than-scrap/prefabs/modules/thruster.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://6f2yjn6wgcun" path="res://code/ship/modules/weapons/weapon_module.gd" id="1_18ma3"]
 [ext_resource type="Script" uid="uid://crmxerc164n6q" path="res://code/weapons/constant_fire_weapon.gd" id="2_5rd74"]
 [ext_resource type="PackedScene" uid="uid://cybvhv36ih1j6" path="res://art/model_prefabs/ship/modules/thruster_model_pf.tscn" id="2_br7jh"]
-[ext_resource type="PackedScene" uid="uid://4ct5vtkfetun" path="res://prefabs/projectiles/thruster_fire.tscn" id="3_24upk"]
+[ext_resource type="PackedScene" uid="uid://bx0real1iddvi" path="res://prefabs/projectiles/thruster_fire.tscn" id="3_xhd0w"]
 [ext_resource type="PackedScene" uid="uid://b5ri43mxkksdw" path="res://prefabs/modules/functional_components/module_display.tscn" id="4_putpi"]
 [ext_resource type="PackedScene" uid="uid://0txf83d46q4j" path="res://prefabs/modules/functional_components/damage_controller.tscn" id="5_24upk"]
 [ext_resource type="PackedScene" uid="uid://hs3ujnysju5o" path="res://prefabs/collision_damage_calculator.tscn" id="6_24upk"]
@@ -37,7 +37,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.898123)
 script = ExtResource("2_5rd74")
 energy_cost = 10.0
 recoil_force = 400.0
-projectile = ExtResource("3_24upk")
+projectile = ExtResource("3_xhd0w")
 
 [node name="ThrusterModel" parent="." instance=ExtResource("2_br7jh")]
 transform = Transform3D(-3.67176e-08, 0, -0.84, 0, 0.84, 0, 0.84, 0, -3.67176e-08, -2.70104e-09, 0, 0.206793)

--- a/faster-than-scrap/prefabs/projectiles/thruster_fire.tscn
+++ b/faster-than-scrap/prefabs/projectiles/thruster_fire.tscn
@@ -70,14 +70,15 @@ player = NodePath("exhaust fire/AnimationPlayer")
 holder = NodePath("exhaust fire")
 
 [node name="DamageRaycast3D" type="RayCast3D" parent="."]
-target_position = Vector3(0, 0, -1)
+target_position = Vector3(0, 0, -1.6)
+collision_mask = 6
 collide_with_areas = true
 collide_with_bodies = false
 script = ExtResource("2_728c8")
 _damage = SubResource("Resource_7ctxp")
 
 [node name="exhaust fire" type="CSGCylinder3D" parent="."]
-transform = Transform3D(-6.61657e-11, -4.36557e-08, -1, -1, -4.37722e-08, 3.18323e-12, -4.4005e-08, 1, -4.3714e-08, -0.000116827, 0.00618755, -0.550639)
+transform = Transform3D(-6.61657e-11, -4.36557e-08, -1, -1, -4.37722e-08, 3.18323e-12, -4.4005e-08, 1, -4.3714e-08, 0, 0, -1)
 radius = 0.25
 smooth_faces = false
 material = ExtResource("4_nqy7r")

--- a/faster-than-scrap/prefabs/projectiles/thruster_fire.tscn
+++ b/faster-than-scrap/prefabs/projectiles/thruster_fire.tscn
@@ -34,7 +34,7 @@ tracks/1/path = NodePath("Thruster_Muzzle:emitting")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
-"times": PackedFloat32Array(0.166667),
+"times": PackedFloat32Array(0.35),
 "transitions": PackedFloat32Array(1),
 "update": 1,
 "values": [false]
@@ -46,7 +46,7 @@ tracks/2/path = NodePath("Thruster_Muzzle:amount_ratio")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
-"times": PackedFloat32Array(0.5),
+"times": PackedFloat32Array(0.35),
 "transitions": PackedFloat32Array(1),
 "update": 0,
 "values": [0.0]
@@ -74,7 +74,7 @@ tracks/1/path = NodePath("Thruster_Muzzle:emitting")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
-"times": PackedFloat32Array(0.5),
+"times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 1,
 "values": [true]
@@ -86,10 +86,10 @@ tracks/2/path = NodePath("Thruster_Muzzle:amount_ratio")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
-"times": PackedFloat32Array(0.5),
-"transitions": PackedFloat32Array(1),
+"times": PackedFloat32Array(0, 0.25),
+"transitions": PackedFloat32Array(1, 1),
 "update": 0,
-"values": [1.0]
+"values": [1.0, 1.0]
 }
 
 [sub_resource type="Animation" id="Animation_dhf0v"]
@@ -171,4 +171,3 @@ movie_quit_on_finish = true
 
 [node name="Thruster_Muzzle" parent="BeamHolder/exhaust fire" instance=ExtResource("6_dhf0v")]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 9.22953e-08, -0.737683, -6.00502e-08)
-visible = false

--- a/faster-than-scrap/prefabs/projectiles/thruster_fire.tscn
+++ b/faster-than-scrap/prefabs/projectiles/thruster_fire.tscn
@@ -171,3 +171,4 @@ movie_quit_on_finish = true
 
 [node name="Thruster_Muzzle" parent="BeamHolder/exhaust fire" instance=ExtResource("6_dhf0v")]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 9.22953e-08, -0.737683, -6.00502e-08)
+visible = false

--- a/faster-than-scrap/prefabs/projectiles/thruster_fire.tscn
+++ b/faster-than-scrap/prefabs/projectiles/thruster_fire.tscn
@@ -1,14 +1,16 @@
-[gd_scene load_steps=11 format=3 uid="uid://4ct5vtkfetun"]
+[gd_scene load_steps=12 format=3 uid="uid://bx0real1iddvi"]
 
-[ext_resource type="Script" uid="uid://dmd8jtmxpdaw0" path="res://code/vfx/beam_vfx_logic.gd" id="1_728c8"]
+[ext_resource type="Script" uid="uid://b86vmkhkjsh2k" path="res://code/weapons/projectiles/beam.gd" id="1_nqy7r"]
 [ext_resource type="Script" uid="uid://buwehho3rx3g0" path="res://code/damage/damage_raycast_3d.gd" id="2_728c8"]
 [ext_resource type="Script" uid="uid://cukcjob61wwp7" path="res://code/damage/damage.gd" id="3_nqy7r"]
 [ext_resource type="Material" uid="uid://c04e0wsb1bqto" path="res://art/materials/vfx/engine_fire.tres" id="4_nqy7r"]
 [ext_resource type="Script" uid="uid://2p7oc4a3141y" path="res://code/utilities/wait_free.gd" id="5_nqy7r"]
+[ext_resource type="PackedScene" uid="uid://mk5ccx4i28ls" path="res://prefabs/vfx/particles/thruster_muzzle.tscn" id="6_dhf0v"]
 
 [sub_resource type="Resource" id="Resource_7ctxp"]
 script = ExtResource("3_nqy7r")
-value = 10.0
+value = 50.0
+type = 0
 
 [sub_resource type="Animation" id="Animation_6ipff"]
 resource_name = "Off"
@@ -24,6 +26,30 @@ tracks/0/keys = {
 "transitions": PackedFloat32Array(1, 0.353553),
 "update": 0,
 "values": [1.0, 0.0]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Thruster_Muzzle:emitting")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0.166667),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("Thruster_Muzzle:amount_ratio")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0.5),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [0.0]
 }
 
 [sub_resource type="Animation" id="Animation_nqy7r"]
@@ -41,6 +67,30 @@ tracks/0/keys = {
 "update": 0,
 "values": [0.0, 1.0]
 }
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Thruster_Muzzle:emitting")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0.5),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("Thruster_Muzzle:amount_ratio")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0.5),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [1.0]
+}
 
 [sub_resource type="Animation" id="Animation_dhf0v"]
 length = 0.001
@@ -56,6 +106,30 @@ tracks/0/keys = {
 "update": 0,
 "values": [0.0]
 }
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Thruster_Muzzle:emitting")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(),
+"transitions": PackedFloat32Array(),
+"update": 1,
+"values": []
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("Thruster_Muzzle:amount_ratio")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [1.0]
+}
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_6ipff"]
 _data = {
@@ -64,28 +138,37 @@ _data = {
 &"RESET": SubResource("Animation_dhf0v")
 }
 
-[node name="TestBeam" type="Node3D" node_paths=PackedStringArray("player", "holder")]
-script = ExtResource("1_728c8")
-player = NodePath("exhaust fire/AnimationPlayer")
-holder = NodePath("exhaust fire")
+[node name="ThrusterFire" type="Node3D" node_paths=PackedStringArray("beam_indicator", "player", "holder")]
+script = ExtResource("1_nqy7r")
+beam_indicator = NodePath("BeamHolder")
+max_length = 2.5
+player = NodePath("BeamHolder/exhaust fire/AnimationPlayer")
+holder = NodePath("BeamHolder/exhaust fire")
 
 [node name="DamageRaycast3D" type="RayCast3D" parent="."]
-target_position = Vector3(0, 0, -1.6)
+target_position = Vector3(0, 0, -2.6)
 collision_mask = 6
 collide_with_areas = true
 collide_with_bodies = false
 script = ExtResource("2_728c8")
 _damage = SubResource("Resource_7ctxp")
 
-[node name="exhaust fire" type="CSGCylinder3D" parent="."]
-transform = Transform3D(-6.61657e-11, -4.36557e-08, -1, -1, -4.37722e-08, 3.18323e-12, -4.4005e-08, 1, -4.3714e-08, 0, 0, -1)
+[node name="BeamHolder" type="Node3D" parent="."]
+
+[node name="exhaust fire" type="CSGCylinder3D" parent="BeamHolder"]
+transform = Transform3D(1.91069e-15, -4.37114e-08, -1, -1, -4.37114e-08, 0, -4.37114e-08, 1, -4.37114e-08, 0, 0, -0.5)
 radius = 0.25
+height = 1.0
 smooth_faces = false
 material = ExtResource("4_nqy7r")
 script = ExtResource("5_nqy7r")
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="exhaust fire"]
+[node name="AnimationPlayer" type="AnimationPlayer" parent="BeamHolder/exhaust fire"]
 libraries = {
 &"": SubResource("AnimationLibrary_6ipff")
 }
 movie_quit_on_finish = true
+
+[node name="Thruster_Muzzle" parent="BeamHolder/exhaust fire" instance=ExtResource("6_dhf0v")]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 9.22953e-08, -0.737683, -6.00502e-08)
+visible = false

--- a/faster-than-scrap/prefabs/vfx/particles/thruster_muzzle.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/thruster_muzzle.tscn
@@ -44,9 +44,9 @@ curve = SubResource("Curve_a44b7")
 [node name="Thruster_Muzzle" type="GPUParticles3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -1.00325)
 cast_shadow = 0
+emitting = false
 amount = 200
 lifetime = 0.23
-preprocess = 0.2
 local_coords = true
 transform_align = 3
 trail_enabled = true

--- a/faster-than-scrap/prefabs/vfx/particles/thruster_muzzle.tscn
+++ b/faster-than-scrap/prefabs/vfx/particles/thruster_muzzle.tscn
@@ -1,0 +1,54 @@
+[gd_scene load_steps=7 format=3 uid="uid://mk5ccx4i28ls"]
+
+[sub_resource type="Curve" id="Curve_nosfs"]
+_data = [Vector2(0, 0), 0.0, 0.0, 0, 0, Vector2(1, 1), 0.0, 0.0, 0, 0]
+point_count = 2
+
+[sub_resource type="CurveTexture" id="CurveTexture_j1wmj"]
+curve = SubResource("Curve_nosfs")
+
+[sub_resource type="ParticleProcessMaterial" id="ParticleProcessMaterial_5nrh6"]
+lifetime_randomness = 0.1
+emission_shape_offset = Vector3(0, 0, 1)
+emission_shape = 2
+emission_sphere_radius = 0.4
+orbit_velocity_min = 9.49949e-08
+orbit_velocity_max = 9.49949e-08
+radial_velocity_min = -2.23517e-05
+radial_velocity_max = -2.23517e-05
+gravity = Vector3(0, 0, 0)
+radial_accel_min = -20.0
+radial_accel_max = -10.0
+tangential_accel_min = -2.23517e-06
+tangential_accel_max = -2.23517e-06
+alpha_curve = SubResource("CurveTexture_j1wmj")
+
+[sub_resource type="Curve" id="Curve_a44b7"]
+_data = [Vector2(0, 0), 0.0, 0.0, 0, 0, Vector2(0.0705009, 1), 0.0, 0.0, 0, 0, Vector2(0.99999, 0), 0.0, 0.0, 0, 0, Vector2(1, 0), 0.0, 0.0, 0, 0]
+point_count = 4
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_3d6pv"]
+transparency = 1
+vertex_color_use_as_albedo = true
+albedo_color = Color(0.825316, 0.223917, 0.182688, 1)
+emission_enabled = true
+emission = Color(0.837435, 0.357466, 0.150487, 1)
+emission_energy_multiplier = 12.0
+use_particle_trails = true
+
+[sub_resource type="RibbonTrailMesh" id="RibbonTrailMesh_twmd2"]
+material = SubResource("StandardMaterial3D_3d6pv")
+size = 0.05
+curve = SubResource("Curve_a44b7")
+
+[node name="Thruster_Muzzle" type="GPUParticles3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -1.00325)
+cast_shadow = 0
+amount = 200
+lifetime = 0.23
+preprocess = 0.2
+local_coords = true
+transform_align = 3
+trail_enabled = true
+process_material = SubResource("ParticleProcessMaterial_5nrh6")
+draw_pass_1 = SubResource("RibbonTrailMesh_twmd2")


### PR DESCRIPTION
Thruster changes:
- Changed colliders to better fit the visual thruster model
- Added illegal attachment zone to thruster nozzle
- Moved side attachment points to center of the thruster "block"
- Fixed collision mask of thruster beam, so that it can deal damage
- Changed thruster beam projectile from beam_vfx_logic to an actual beam, so that it can scale correctly and react to the environment
- Added beam damage particles (same as in regular beam)
- Created a prototype thruster particle effect (hidden for now, but can be enabled in `thruster_fire.tscn` (set the Thruster_Muzzle node to visible))
- Changed asteroids hp to be float instead of int (all other hps are also floats). Int type caused the per-frame beam damage to be rounded in a weird way and deal unproportionately high damage to asteroids in every frame