### PR TITLE
Fix modules selectable through UI in ship builder

### DIFF
--- a/faster-than-scrap/code/building_ship/ship_builder.gd
+++ b/faster-than-scrap/code/building_ship/ship_builder.gd
@@ -32,7 +32,6 @@ const RAY_LENGTH = 1000.0
 ## time of warning flash animation
 @export_custom(PROPERTY_HINT_NONE, "suffix:sec") var flash_time: float
 @export var choose_key_message: Control
-@export var confirm_finish_message: Control
 
 @export_group("Sounds")
 @export var pick_sound: SoundEmitterGlobal
@@ -355,7 +354,7 @@ func _input(event: InputEvent):
 
 	match state:
 		State.NONE:
-			if confirm_finish_message.visible || choose_key_message.visible:
+			if choose_key_message.visible:
 				return
 			if _lmb_just_pressed():
 				var hit := _get_raycast_hit(event)
@@ -382,7 +381,7 @@ func _input(event: InputEvent):
 				else:
 					on_module_hover.emit(null)
 		State.DRAGGING:
-			if confirm_finish_message.visible || choose_key_message.visible:
+			if choose_key_message.visible:
 				return
 			if _lmb_just_pressed():
 				_on_lmb_release()
@@ -579,23 +578,10 @@ func _flash_module(module: Module) -> void:
 		tween.play()
 
 
-func _on_finish_pressed() -> void:
-	confirm_finish_message.visible = true
-
-
 func _on_asign_key_cancel_pressed() -> void:
 	state = State.NONE
 	choose_key_message.visible = false
 	print("new state = none")
-
-
-func _on_confirm_pressed() -> void:
-	confirm_finish_message.visible = false
-	scene_loader.load_fly_ship_scene()
-
-
-func _on_deny_pressed() -> void:
-	confirm_finish_message.visible = false
 
 
 func set_freeze_mode(is_frozen: bool):

--- a/faster-than-scrap/code/building_ship/ship_builder.gd
+++ b/faster-than-scrap/code/building_ship/ship_builder.gd
@@ -64,6 +64,10 @@ var rmb_was_pressed: bool = false
 var ignore_rid: Array[RID]
 var scene_loader: SceneLoader
 
+## set to false when there are menus or messages displayed on the screen
+## (e.g. "you cannot leave without paying")
+var can_interact_with_modules: bool = true
+
 
 func _ready() -> void:
 	scene_loader = $SceneLoader
@@ -335,6 +339,10 @@ func _can_module_have_assigned_key(active_module: Module) -> bool:
 func _input(event: InputEvent):
 	_update_lmb_state(event)
 	_update_mouse_3d_position()
+
+	if not can_interact_with_modules:
+		return
+
 	if (
 		event is InputEventKey
 		and event.pressed == true
@@ -578,6 +586,7 @@ func _on_finish_pressed() -> void:
 func _on_asign_key_cancel_pressed() -> void:
 	state = State.NONE
 	choose_key_message.visible = false
+	print("new state = none")
 
 
 func _on_confirm_pressed() -> void:

--- a/faster-than-scrap/code/building_ship/shop.gd
+++ b/faster-than-scrap/code/building_ship/shop.gd
@@ -60,9 +60,16 @@ func _ready() -> void:
 	MissionManager.map_finished.connect(_clear_shop)
 	MissionManager.map_finished.connect(ShopContents.generate_contents)
 
+	GameManager.new_game_state.connect(_on_game_manager_new_game_state)
+
 	_generate_shop()
 
 	_update_repair_button_visibility()
+
+
+func _on_game_manager_new_game_state(new_state: GameState.State) -> void:
+	if new_state == GameState.State.BUILD:
+		_update_repair_button_visibility()
 
 
 func _clear_shop() -> void:

--- a/faster-than-scrap/code/building_ship/shop.gd
+++ b/faster-than-scrap/code/building_ship/shop.gd
@@ -29,7 +29,6 @@ extends Node3D
 @export var inventory_limit_display: Label3D
 
 @export var deny_finish: Control
-@export var confirm_finish: Control
 
 @export var deny_finish_label: Label
 @export var selected_module_prize_display: Label
@@ -202,7 +201,6 @@ func _show_warning(warning_text: String) -> void:
 
 
 func _exit_shop() -> void:
-	#confirm_finish.visible = true
 	$"../ShipBuilder/SceneLoader".load_fly_ship_scene()
 	GameManager.player_ship.money = bank
 

--- a/faster-than-scrap/default_bus_layout.tres
+++ b/faster-than-scrap/default_bus_layout.tres
@@ -26,5 +26,5 @@ bus/3/name = &"UI"
 bus/3/solo = false
 bus/3/mute = false
 bus/3/bypass_fx = false
-bus/3/volume_db = -2
+bus/3/volume_db = -2.0
 bus/3/send = &"Master"

--- a/faster-than-scrap/scenes/build_ship.tscn
+++ b/faster-than-scrap/scenes/build_ship.tscn
@@ -350,9 +350,10 @@ horizontal_alignment = 1
 script = ExtResource("7_jtm63")
 metadata/_custom_type_script = "uid://16i5n2yxnlsr"
 
-[node name="Shop" type="Node3D" parent="." node_paths=PackedStringArray("bank_display", "inventory_limit_display", "deny_finish", "confirm_finish", "deny_finish_label", "selected_module_display", "selected_module_description", "repair_button", "confirm_finish_message_with_unassigned_keys", "warning_sound")]
+[node name="Shop" type="Node3D" parent="." node_paths=PackedStringArray("ship_builder", "bank_display", "inventory_limit_display", "deny_finish", "confirm_finish", "deny_finish_label", "selected_module_display", "selected_module_description", "repair_button", "confirm_finish_message_with_unassigned_keys", "warning_sound")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 15.897, 0, -3.63634)
 script = ExtResource("11_jtm63")
+ship_builder = NodePath("../ShipBuilder")
 starting_bank = 6
 size_x = 10.0
 size_z = 10.0

--- a/faster-than-scrap/scenes/build_ship.tscn
+++ b/faster-than-scrap/scenes/build_ship.tscn
@@ -107,7 +107,7 @@ font_color = Color(0.105882, 1, 0.105882, 1)
 
 [node name="SpaceEnvironment" parent="." instance=ExtResource("1_8ccmg")]
 
-[node name="ShipBuilder" type="Node3D" parent="." node_paths=PackedStringArray("ignore", "ship_borders", "choose_key_message", "confirm_finish_message", "pick_sound", "cannot_pick_sound", "rotate_sound", "cannot_rotate_sound", "attach_sound", "place_sound", "cannot_place_sound", "start_assigning_key_sound", "assign_key_sound")]
+[node name="ShipBuilder" type="Node3D" parent="." node_paths=PackedStringArray("ignore", "ship_borders", "choose_key_message", "pick_sound", "cannot_pick_sound", "rotate_sound", "cannot_rotate_sound", "attach_sound", "place_sound", "cannot_place_sound", "start_assigning_key_sound", "assign_key_sound")]
 script = ExtResource("1_d5jmr")
 ignore = [NodePath("../Shop/BuildArea"), NodePath("../Shop/Inventory/Area3D"), NodePath("../Ship Max Size/Area3D")]
 ship_borders = NodePath("../Ship Max Size/Area3D")
@@ -115,7 +115,6 @@ outline_mat = ExtResource("3_7x66o")
 flash_mat = ExtResource("4_sra6p")
 flash_time = 0.5
 choose_key_message = NodePath("Control/Choose_key")
-confirm_finish_message = NodePath("Control/Confirm finish")
 pick_sound = NodePath("../PickSound")
 cannot_pick_sound = NodePath("../CannotPickSound")
 rotate_sound = NodePath("../RotateSound")
@@ -180,66 +179,6 @@ theme_override_styles/hover = SubResource("StyleBoxFlat_cv5l0")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_hbg4l")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_q6ms4")
 text = "OK"
-
-[node name="Confirm finish" type="ColorRect" parent="ShipBuilder/Control"]
-visible = false
-layout_mode = 0
-offset_right = 1150.0
-offset_bottom = 650.0
-color = Color(0, 0, 0, 0.9)
-
-[node name="Color_Rect" type="ColorRect" parent="ShipBuilder/Control/Confirm finish"]
-layout_mode = 0
-offset_left = 248.0
-offset_top = 242.0
-offset_right = 898.0
-offset_bottom = 392.0
-color = Color(0, 0.051, 0.027, 1)
-
-[node name="Label" type="Label" parent="ShipBuilder/Control/Confirm finish/Color_Rect"]
-layout_mode = 0
-offset_right = 250.0
-offset_bottom = 50.0
-text = "WARNING: Unattached modules will be lost"
-label_settings = SubResource("LabelSettings_x5wpm")
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="Confirm" type="Button" parent="ShipBuilder/Control/Confirm finish/Color_Rect"]
-layout_mode = 0
-offset_left = 390.0
-offset_top = 76.0
-offset_right = 608.0
-offset_bottom = 114.0
-theme_override_colors/font_hover_color = Color(0.105882, 1, 0.105882, 1)
-theme_override_colors/font_color = Color(0.105882, 1, 0.105882, 1)
-theme_override_colors/font_focus_color = Color(0.105882, 1, 0.105882, 1)
-theme_override_colors/font_pressed_color = Color(0, 0.0509804, 0.027451, 1)
-theme_override_fonts/font = ExtResource("6_au3vu")
-theme_override_font_sizes/font_size = 30
-theme_override_styles/focus = SubResource("StyleBoxEmpty_ukoue")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ppglm")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_istkh")
-theme_override_styles/normal = SubResource("StyleBoxEmpty_xrmp7")
-text = "Proceed"
-
-[node name="Deny" type="Button" parent="ShipBuilder/Control/Confirm finish/Color_Rect"]
-layout_mode = 0
-offset_left = 20.0
-offset_top = 76.0
-offset_right = 238.0
-offset_bottom = 114.0
-theme_override_colors/font_hover_color = Color(0.105882, 1, 0.105882, 1)
-theme_override_colors/font_color = Color(0.105882, 1, 0.105882, 1)
-theme_override_colors/font_focus_color = Color(0.105882, 1, 0.105882, 1)
-theme_override_colors/font_pressed_color = Color(0, 0.0509804, 0.027451, 1)
-theme_override_fonts/font = ExtResource("6_au3vu")
-theme_override_font_sizes/font_size = 30
-theme_override_styles/focus = SubResource("StyleBoxEmpty_ukoue")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ppglm")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_istkh")
-theme_override_styles/normal = SubResource("StyleBoxEmpty_xrmp7")
-text = "Go Back"
 
 [node name="Choose_key" type="ColorRect" parent="ShipBuilder/Control"]
 visible = false
@@ -350,7 +289,7 @@ horizontal_alignment = 1
 script = ExtResource("7_jtm63")
 metadata/_custom_type_script = "uid://16i5n2yxnlsr"
 
-[node name="Shop" type="Node3D" parent="." node_paths=PackedStringArray("ship_builder", "bank_display", "inventory_limit_display", "deny_finish", "confirm_finish", "deny_finish_label", "selected_module_display", "selected_module_description", "repair_button", "confirm_finish_message_with_unassigned_keys", "warning_sound")]
+[node name="Shop" type="Node3D" parent="." node_paths=PackedStringArray("ship_builder", "bank_display", "inventory_limit_display", "deny_finish", "deny_finish_label", "selected_module_display", "selected_module_description", "repair_button", "confirm_finish_message_with_unassigned_keys", "warning_sound")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 15.897, 0, -3.63634)
 script = ExtResource("11_jtm63")
 ship_builder = NodePath("../ShipBuilder")
@@ -362,7 +301,6 @@ rows = 5
 bank_display = NodePath("Inventory4")
 inventory_limit_display = NodePath("Inventory/InventoryLimitLabel")
 deny_finish = NodePath("../ShipBuilder/Control/Deny finish")
-confirm_finish = NodePath("../ShipBuilder/Control/Confirm finish")
 deny_finish_label = NodePath("../ShipBuilder/Control/Deny finish/Color_Rect/Label")
 selected_module_display = NodePath("../ShipBuilder/Control/Prize_display/RichTextLabel")
 selected_module_description = NodePath("../ShipBuilder/Control/Description_display/RichTextLabel")
@@ -670,8 +608,6 @@ metadata/_custom_type_script = "uid://c6mohg4o53eqe"
 [connection signal="on_module_detach" from="ShipBuilder" to="Shop" method="_on_ship_builder_on_module_detach"]
 [connection signal="on_module_hover" from="ShipBuilder" to="Shop" method="_on_ship_builder_on_module_select"]
 [connection signal="pressed" from="ShipBuilder/Control/Deny finish/Color_Rect/Confirm" to="Shop" method="_on_confirm_pressed"]
-[connection signal="pressed" from="ShipBuilder/Control/Confirm finish/Color_Rect/Confirm" to="ShipBuilder" method="_on_confirm_pressed"]
-[connection signal="pressed" from="ShipBuilder/Control/Confirm finish/Color_Rect/Deny" to="ShipBuilder" method="_on_deny_pressed"]
 [connection signal="pressed" from="ShipBuilder/Control/Choose_key/Color_Rect/Cancel" to="ShipBuilder" method="_on_asign_key_cancel_pressed"]
 [connection signal="pressed" from="ShipBuilder/Control/Finish" to="Shop" method="_on_finish_pressed"]
 [connection signal="area_entered" from="Shop/Inventory/Area3D" to="Shop" method="_on_inventory_entered"]

--- a/faster-than-scrap/scenes/tutorials/build_ship_tutorial.tscn
+++ b/faster-than-scrap/scenes/tutorials/build_ship_tutorial.tscn
@@ -390,9 +390,10 @@ horizontal_alignment = 1
 script = ExtResource("7_rimmj")
 metadata/_custom_type_script = "uid://16i5n2yxnlsr"
 
-[node name="Shop" type="Node3D" parent="." node_paths=PackedStringArray("bank_display", "deny_finish", "confirm_finish", "deny_finish_label", "selected_module_display", "selected_module_description", "repair_button", "confirm_finish_message_with_unassigned_keys", "warning_sound")]
+[node name="Shop" type="Node3D" parent="." node_paths=PackedStringArray("ship_builder", "bank_display", "deny_finish", "confirm_finish", "deny_finish_label", "selected_module_display", "selected_module_description", "repair_button", "confirm_finish_message_with_unassigned_keys", "warning_sound")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 15.897, 0, -3.63634)
 script = ExtResource("8_hc2q3")
+ship_builder = NodePath("../ShipBuilder")
 starting_bank = 6
 size_x = 10.0
 size_z = 10.0

--- a/faster-than-scrap/scenes/tutorials/build_ship_tutorial.tscn
+++ b/faster-than-scrap/scenes/tutorials/build_ship_tutorial.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=63 format=3 uid="uid://dom21c42bbjwl"]
+[gd_scene load_steps=58 format=3 uid="uid://dom21c42bbjwl"]
 
 [ext_resource type="PackedScene" uid="uid://b670jj7lnajsd" path="res://prefabs/environment/space_environment.tscn" id="1_mjhpt"]
 [ext_resource type="Script" uid="uid://dsxm6i5w4uh08" path="res://code/building_ship/ship_builder.gd" id="2_esu31"]
@@ -39,20 +39,6 @@ bg_color = Color(0, 0.2, 0.106667, 1)
 bg_color = Color(0.105882, 1, 0.105882, 1)
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_q6ms4"]
-
-[sub_resource type="LabelSettings" id="LabelSettings_x5wpm"]
-font = ExtResource("6_hk4jn")
-font_color = Color(0.105882, 1, 0.105882, 1)
-
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_ukoue"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ppglm"]
-bg_color = Color(0, 0.2, 0.106667, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_istkh"]
-bg_color = Color(0.105882, 1, 0.105882, 1)
-
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_xrmp7"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_flqfh"]
 font = ExtResource("6_hk4jn")
@@ -147,7 +133,7 @@ bg_color = Color(0.105882, 1, 0.105882, 1)
 
 [node name="SpaceEnvironment" parent="." instance=ExtResource("1_mjhpt")]
 
-[node name="ShipBuilder" type="Node3D" parent="." node_paths=PackedStringArray("ignore", "ship_borders", "choose_key_message", "confirm_finish_message", "pick_sound", "cannot_pick_sound", "rotate_sound", "cannot_rotate_sound", "attach_sound", "place_sound", "cannot_place_sound", "start_assigning_key_sound", "assign_key_sound")]
+[node name="ShipBuilder" type="Node3D" parent="." node_paths=PackedStringArray("ignore", "ship_borders", "choose_key_message", "pick_sound", "cannot_pick_sound", "rotate_sound", "cannot_rotate_sound", "attach_sound", "place_sound", "cannot_place_sound", "start_assigning_key_sound", "assign_key_sound")]
 script = ExtResource("2_esu31")
 ignore = [NodePath("../Shop/BuildArea"), NodePath("../Ship Max Size/Area3D")]
 ship_borders = NodePath("../Ship Max Size/Area3D")
@@ -155,7 +141,6 @@ outline_mat = ExtResource("3_b0l23")
 flash_mat = ExtResource("4_0f5k8")
 flash_time = 0.5
 choose_key_message = NodePath("Control/Choose_key")
-confirm_finish_message = NodePath("Control/Confirm finish")
 pick_sound = NodePath("../PickSound")
 cannot_pick_sound = NodePath("../CannotPickSound")
 rotate_sound = NodePath("../RotateSound")
@@ -220,66 +205,6 @@ theme_override_styles/hover = SubResource("StyleBoxFlat_cv5l0")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_hbg4l")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_q6ms4")
 text = "OK"
-
-[node name="Confirm finish" type="ColorRect" parent="ShipBuilder/Control"]
-visible = false
-layout_mode = 0
-offset_right = 1150.0
-offset_bottom = 650.0
-color = Color(0, 0, 0, 0.9)
-
-[node name="Color_Rect" type="ColorRect" parent="ShipBuilder/Control/Confirm finish"]
-layout_mode = 0
-offset_left = 248.0
-offset_top = 242.0
-offset_right = 898.0
-offset_bottom = 392.0
-color = Color(0, 0.051, 0.027, 1)
-
-[node name="Label" type="Label" parent="ShipBuilder/Control/Confirm finish/Color_Rect"]
-layout_mode = 0
-offset_right = 250.0
-offset_bottom = 50.0
-text = "WARNING: Unattached modules will be lost"
-label_settings = SubResource("LabelSettings_x5wpm")
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="Confirm" type="Button" parent="ShipBuilder/Control/Confirm finish/Color_Rect"]
-layout_mode = 0
-offset_left = 390.0
-offset_top = 76.0
-offset_right = 608.0
-offset_bottom = 114.0
-theme_override_colors/font_hover_color = Color(0.105882, 1, 0.105882, 1)
-theme_override_colors/font_color = Color(0.105882, 1, 0.105882, 1)
-theme_override_colors/font_focus_color = Color(0.105882, 1, 0.105882, 1)
-theme_override_colors/font_pressed_color = Color(0, 0.0509804, 0.027451, 1)
-theme_override_fonts/font = ExtResource("6_hk4jn")
-theme_override_font_sizes/font_size = 30
-theme_override_styles/focus = SubResource("StyleBoxEmpty_ukoue")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ppglm")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_istkh")
-theme_override_styles/normal = SubResource("StyleBoxEmpty_xrmp7")
-text = "Proceed"
-
-[node name="Deny" type="Button" parent="ShipBuilder/Control/Confirm finish/Color_Rect"]
-layout_mode = 0
-offset_left = 20.0
-offset_top = 76.0
-offset_right = 238.0
-offset_bottom = 114.0
-theme_override_colors/font_hover_color = Color(0.105882, 1, 0.105882, 1)
-theme_override_colors/font_color = Color(0.105882, 1, 0.105882, 1)
-theme_override_colors/font_focus_color = Color(0.105882, 1, 0.105882, 1)
-theme_override_colors/font_pressed_color = Color(0, 0.0509804, 0.027451, 1)
-theme_override_fonts/font = ExtResource("6_hk4jn")
-theme_override_font_sizes/font_size = 30
-theme_override_styles/focus = SubResource("StyleBoxEmpty_ukoue")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ppglm")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_istkh")
-theme_override_styles/normal = SubResource("StyleBoxEmpty_xrmp7")
-text = "Go Back"
 
 [node name="Choose_key" type="ColorRect" parent="ShipBuilder/Control"]
 visible = false
@@ -390,7 +315,7 @@ horizontal_alignment = 1
 script = ExtResource("7_rimmj")
 metadata/_custom_type_script = "uid://16i5n2yxnlsr"
 
-[node name="Shop" type="Node3D" parent="." node_paths=PackedStringArray("ship_builder", "bank_display", "deny_finish", "confirm_finish", "deny_finish_label", "selected_module_display", "selected_module_description", "repair_button", "confirm_finish_message_with_unassigned_keys", "warning_sound")]
+[node name="Shop" type="Node3D" parent="." node_paths=PackedStringArray("ship_builder", "bank_display", "deny_finish", "deny_finish_label", "selected_module_display", "selected_module_description", "repair_button", "confirm_finish_message_with_unassigned_keys", "warning_sound")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 15.897, 0, -3.63634)
 script = ExtResource("8_hc2q3")
 ship_builder = NodePath("../ShipBuilder")
@@ -401,7 +326,6 @@ columns = 3
 rows = 5
 bank_display = NodePath("Inventory4")
 deny_finish = NodePath("../ShipBuilder/Control/Deny finish")
-confirm_finish = NodePath("../ShipBuilder/Control/Confirm finish")
 deny_finish_label = NodePath("../ShipBuilder/Control/Deny finish/Color_Rect/Label")
 selected_module_display = NodePath("../ShipBuilder/Control/Prize_display/RichTextLabel")
 selected_module_description = NodePath("../ShipBuilder/Control/Description_display/RichTextLabel")
@@ -683,8 +607,6 @@ metadata/_custom_type_script = "uid://c6mohg4o53eqe"
 [connection signal="on_module_detach" from="ShipBuilder" to="Shop" method="_on_ship_builder_on_module_detach"]
 [connection signal="on_module_hover" from="ShipBuilder" to="Shop" method="_on_ship_builder_on_module_select"]
 [connection signal="pressed" from="ShipBuilder/Control/Deny finish/Color_Rect/Confirm" to="Shop" method="_on_confirm_pressed"]
-[connection signal="pressed" from="ShipBuilder/Control/Confirm finish/Color_Rect/Confirm" to="ShipBuilder" method="_on_confirm_pressed"]
-[connection signal="pressed" from="ShipBuilder/Control/Confirm finish/Color_Rect/Deny" to="ShipBuilder" method="_on_deny_pressed"]
 [connection signal="pressed" from="ShipBuilder/Control/Choose_key/Color_Rect/Cancel" to="ShipBuilder" method="_on_asign_key_cancel_pressed"]
 [connection signal="pressed" from="ShipBuilder/Control/Finish" to="Shop" method="_on_finish_pressed"]
 [connection signal="pressed" from="Control/RepairModules" to="Shop" method="_repair_modules"]


### PR DESCRIPTION
Disable interaction with modules when a message is visible

Also fixed repair button always being visible after exiting and entering the shop (even if there is nothing to repair)