### PR TITLE
Faster debug movement

### DIFF
--- a/faster-than-scrap/code/player/player_ship.gd
+++ b/faster-than-scrap/code/player/player_ship.gd
@@ -96,7 +96,7 @@ func _physics_process(_delta: float) -> void:
 		input_direction.y,
 	)
 
-	apply_force(force_direction * debug_movement_force)
+	apply_force(force_direction * debug_movement_force * mass)
 
 
 func change_air_resistance() -> void:


### PR DESCRIPTION
Debug movement force is now multiplied by ship mass, so that heavier player ships will still move fast using the debug movement.