### PR TITLE
Fix entering shops causing incorrect start position

### DIFF
--- a/faster-than-scrap/code/player/player_ship.gd
+++ b/faster-than-scrap/code/player/player_ship.gd
@@ -133,6 +133,14 @@ func get_saved_rotation():
 	return _saved_rotation
 
 
+func clear_saved_position():
+	_saved_position = Vector3.ZERO
+
+
+func clear_saved_rotation():
+	_saved_rotation = Vector3.ZERO
+
+
 ## Called whenever the energy amount changes.
 func _on_energy_change() -> void:
 	super()

--- a/faster-than-scrap/code/scene_loader.gd
+++ b/faster-than-scrap/code/scene_loader.gd
@@ -71,6 +71,8 @@ func load_fly_ship_scene(
 	if use_saved_pos_rot and GameManager.player_ship != null:
 		pos = GameManager.player_ship.get_saved_position()
 		rot = GameManager.player_ship.get_saved_rotation()
+		GameManager.player_ship.clear_saved_position()
+		GameManager.player_ship.clear_saved_rotation()
 
 	_attach_ship_with_hud.call_deferred(pos, rot)
 


### PR DESCRIPTION
Levels were started in position previously saved when entering the shop, not in (0,0,0). Solved by clearing the saved position after loading it (when exiting the shop)