### PR TITLE
Fix the spaghetti fix

### DIFF
--- a/faster-than-scrap/code/player/player_ship.gd
+++ b/faster-than-scrap/code/player/player_ship.gd
@@ -37,9 +37,6 @@ var _saved_rotation: Vector3 = Vector3.ZERO
 func _enter_tree() -> void:
 	GameManager.player_ship = self
 	center_of_mass_mode = RigidBody3D.CENTER_OF_MASS_MODE_CUSTOM
-	# spaghetti fix
-	max_energy = 200
-	energy = 200
 
 
 func _ready() -> void:

--- a/faster-than-scrap/code/ship/ship.gd
+++ b/faster-than-scrap/code/ship/ship.gd
@@ -12,7 +12,10 @@ signal damaged(hp_percent: float)
 	set(value):
 		var start_energy = energy
 		energy = value
-		if energy > max_energy:
+		if energy > max_energy and is_node_ready():
+			# the is_node_ready() check is needed because Godot calls the setter
+			# just after starting the game, if the default value is changed from the editor
+			# in overriding class (PlayerShip in this case) - a bug in Godot, probably?
 			energy = max_energy
 		if energy != start_energy:
 			_on_energy_change()

--- a/faster-than-scrap/scenes/tutorials/basic_movement_tutorial.tscn
+++ b/faster-than-scrap/scenes/tutorials/basic_movement_tutorial.tscn
@@ -192,7 +192,7 @@ cutscene_path = ExtResource("10_aa5ti")
 
 [node name="Detect player low energy" type="Node" parent="Energy cutscene player"]
 script = ExtResource("11_37dpr")
-percentage = 0.8
+percentage = 0.9
 
 [node name="Weapon Cutscene player" type="Area3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -380)


### PR DESCRIPTION
Fixes ship energy being hardcoded to 200, introduced in #592

Also increases energy percentage trigger to make the energy warning show sooner (it's possible that it won't show at all if the player doesn't use too much energy in the tutorial)